### PR TITLE
add whitelist_impl.h to include for dist

### DIFF
--- a/src/modules/whitelist/Makefile.am.include
+++ b/src/modules/whitelist/Makefile.am.include
@@ -1,3 +1,4 @@
 include_HEADERS += include/secp256k1_whitelist.h
+noinst_HEADERS += src/modules/whitelist/whitelist_impl.h
 noinst_HEADERS += src/modules/whitelist/main_impl.h
 noinst_HEADERS += src/modules/whitelist/tests_impl.h


### PR DESCRIPTION
should fix `make distcheck` when module enabled.