### PR TITLE
Expose generator in shared library

### DIFF
--- a/include/secp256k1_rangeproof.h
+++ b/include/secp256k1_rangeproof.h
@@ -28,7 +28,7 @@ typedef struct {
 /**
  * Static constant generator 'h' maintained for historical reasons.
  */
-extern const secp256k1_generator *secp256k1_generator_h;
+SECP256K1_API extern const secp256k1_generator *secp256k1_generator_h;
 
 /** Parse a 33-byte commitment into a commitment object.
  *


### PR DESCRIPTION
Was failing linking to `*.so` library