### PR TITLE
export sizeof(secp256k1_surjectionproof) as SECP256K1_SURJECTIONPROOF_RAW_SIZE

### DIFF
--- a/include/secp256k1_surjectionproof.h
+++ b/include/secp256k1_surjectionproof.h
@@ -33,6 +33,11 @@ extern "C" {
  *  and secp256k1_surjectionproof_serialize to encode/decode proofs into a
  *  well-defined format.
  *
+ *  If you need to allocate new secp256k1_surjectionproof structure
+ *  for use with secp256k1_surjectionproof_initialize, you should allocate
+ *  a buffer of size SECP256K1_SURJECTIONPROOF_RAW_SIZE, and then treat the
+ *  data in this buffer as opaque data, as described above.
+ *
  *  The representation is exposed to allow creation of these objects on the
  *  stack; please *do not* use these internals directly.
  */
@@ -48,6 +53,8 @@ typedef struct {
     /** Borromean signature: e0, scalars */
     unsigned char data[32 * (1 + SECP256K1_SURJECTIONPROOF_MAX_N_INPUTS)];
 } secp256k1_surjectionproof;
+
+SECP256K1_API const int SECP256K1_SURJECTIONPROOF_RAW_SIZE;
 
 /** Parse a surjection proof
  *

--- a/include/secp256k1_surjectionproof.h
+++ b/include/secp256k1_surjectionproof.h
@@ -54,7 +54,7 @@ typedef struct {
     unsigned char data[32 * (1 + SECP256K1_SURJECTIONPROOF_MAX_N_INPUTS)];
 } secp256k1_surjectionproof;
 
-SECP256K1_API const int SECP256K1_SURJECTIONPROOF_RAW_SIZE;
+#define SECP256K1_SURJECTIONPROOF_RAW_SIZE sizeof(secp256k1_surjectionproof)
 
 /** Parse a surjection proof
  *

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -740,5 +740,11 @@ int secp256k1_ec_pubkey_combine(const secp256k1_context* ctx, secp256k1_pubkey *
 
 #ifdef ENABLE_MODULE_SURJECTIONPROOF
 # include "modules/surjection/main_impl.h"
-const int SECP256K1_SURJECTIONPROOF_RAW_SIZE = sizeof(secp256k1_surjectionproof);
+/* In the headers, SECP256K1_SURJECTIONPROOF_RAW_SIZE is #defined
+ * as sizeof(secp256k1_surjectionproof), so it can be used in C code
+ * to do allocate the structure on stack, using that name.
+ * In this file, this #define is not be used, and we can safely
+ * #undef it to be able to define the exported symbol with the same name. */
+#undef SECP256K1_SURJECTIONPROOF_RAW_SIZE
+SECP256K1_API const int SECP256K1_SURJECTIONPROOF_RAW_SIZE = sizeof(secp256k1_surjectionproof);
 #endif

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -740,4 +740,5 @@ int secp256k1_ec_pubkey_combine(const secp256k1_context* ctx, secp256k1_pubkey *
 
 #ifdef ENABLE_MODULE_SURJECTIONPROOF
 # include "modules/surjection/main_impl.h"
+const int SECP256K1_SURJECTIONPROOF_RAW_SIZE = sizeof(secp256k1_surjectionproof);
 #endif


### PR DESCRIPTION
the rationale is explained in #36 - knowing the struct size used in particular version of the library enables to alloc the struct without access to `secp256k1_surjectionproof.h`

For example, with python:

```
>>> import ctypes
>>> secp256k1 = ctypes.cdll.LoadLibrary('.libs/libsecp256k1.so')
>>> surjectionproof_size = ctypes.c_int.in_dll(secp256k1, 'SECP256K1_SURJECTIONPROOF_RAW_SIZE').value
>>> surjectionproof_size
8264
>>> proof = ctypes.create_string_buffer(surjectionproof_size)

# secp256k1.secp256k1_surjectionproof_initialize(secp256k1_blind_context, proof, ...)

```