### PR TITLE
generator: remove `CHECK` abort calls exposed by public API

### DIFF
--- a/src/modules/generator/main_impl.h
+++ b/src/modules/generator/main_impl.h
@@ -175,7 +175,6 @@ static int secp256k1_generator_generate_internal(const secp256k1_context* ctx, s
         secp256k1_scalar blind;
         secp256k1_scalar_set_b32(&blind, blind32, &overflow);
         ret = !overflow;
-        CHECK(ret);
         secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &accum, &blind);
     }
 
@@ -184,7 +183,6 @@ static int secp256k1_generator_generate_internal(const secp256k1_context* ctx, s
     secp256k1_sha256_write(&sha256, key32, 32);
     secp256k1_sha256_finalize(&sha256, b32);
     ret &= secp256k1_fe_set_b32(&t, b32);
-    CHECK(ret);
     shallue_van_de_woestijne(&add, &t);
     if (blind32) {
         secp256k1_gej_add_ge(&accum, &accum, &add);
@@ -197,7 +195,6 @@ static int secp256k1_generator_generate_internal(const secp256k1_context* ctx, s
     secp256k1_sha256_write(&sha256, key32, 32);
     secp256k1_sha256_finalize(&sha256, b32);
     ret &= secp256k1_fe_set_b32(&t, b32);
-    CHECK(ret);
     shallue_van_de_woestijne(&add, &t);
     secp256k1_gej_add_ge(&accum, &accum, &add);
 

--- a/src/modules/generator/tests_impl.h
+++ b/src/modules/generator/tests_impl.h
@@ -173,7 +173,7 @@ void test_generator_generate(void) {
     secp256k1_ge_storage ges;
     int i;
     unsigned char v[32];
-    static const unsigned char s[32] = {0};
+    unsigned char s[32] = {0};
     secp256k1_scalar sc;
     secp256k1_scalar_set_b32(&sc, s, NULL);
     for (i = 1; i <= 32; i++) {
@@ -188,6 +188,14 @@ void test_generator_generate(void) {
         secp256k1_ge_to_storage(&ges, &ge);
         CHECK(memcmp(&ges, &results[i - 1], sizeof(secp256k1_ge_storage)) == 0);
     }
+
+    /* There is no range restriction on the value, but the blinder must be a
+     * valid scalar. Check that an invalid blinder causes the call to fail
+     * but not crash. */
+    memset(v, 0xff, 32);
+    CHECK(secp256k1_generator_generate(ctx, &gen, v));
+    memset(s, 0xff, 32);
+    CHECK(!secp256k1_generator_generate_blinded(ctx, &gen, v, s));
 }
 
 void test_generator_fixed_vector(void) {


### PR DESCRIPTION
Fixes #49 