### PR TITLE
add allocate/destroy functions for secp256k1_surjectionproof

### DIFF
--- a/include/secp256k1_surjectionproof.h
+++ b/include/secp256k1_surjectionproof.h
@@ -134,6 +134,7 @@ SECP256K1_API size_t secp256k1_surjectionproof_serialized_size(
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2);
 
 /** Surjection proof initialization function; decides on inputs to use
+ *  To be used to initialize stack-allocated secp256k1_surjectionproof struct
  * Returns 0: inputs could not be selected
  *         n: inputs were selected after n iterations of random selection
  *
@@ -165,6 +166,51 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_surjectionproof_initial
   const size_t n_max_iterations,
   const unsigned char *random_seed32
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4) SECP256K1_ARG_NONNULL(7);
+
+
+/** Surjection proof allocation and initialization function; decides on inputs to use
+ * Returns 0: inputs could not be selected, or malloc failure
+ *         n: inputs were selected after n iterations of random selection
+ *
+ * In:               ctx: pointer to a context object
+ *           proof_out_p: a pointer to a pointer to `secp256k1_surjectionproof*`.
+ *                        the newly-allocated struct pointer will be saved here.
+ *      fixed_input_tags: fixed input tags `A_i` for all inputs. (If the fixed tag is not known,
+ *                        e.g. in a coinjoin with others' inputs, an ephemeral tag can be given;
+ *                        this won't match the output tag but might be used in the anonymity set.)
+ *          n_input_tags: the number of entries in the fixed_input_tags array
+ *      n_input_tags_to_use: the number of inputs to select randomly to put in the anonymity set
+ *      fixed_output_tag: fixed output tag
+ *      max_n_iterations: the maximum number of iterations to do before giving up. Because the
+ *                        maximum number of inputs (SECP256K1_SURJECTIONPROOF_MAX_N_INPUTS) is
+ *                        limited to 256 the probability of giving up is smaller than
+ *                        (255/256)^(n_input_tags_to_use*max_n_iterations).
+ *
+ *         random_seed32: a random seed to be used for input selection
+ * Out:      proof_out_p: The pointer to newly-allocated proof whose bitvector will be initialized.
+ *                        In case of failure, the pointer will be NULL.
+ *          input_index: The index of the actual input that is secretly mapped to the output
+ */
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_surjectionproof_allocate_initialized(
+        const secp256k1_context* ctx,
+        secp256k1_surjectionproof** proof_out_p,
+        size_t *input_index,
+        const secp256k1_fixed_asset_tag* fixed_input_tags,
+        const size_t n_input_tags,
+        const size_t n_input_tags_to_use,
+        const secp256k1_fixed_asset_tag* fixed_output_tag,
+        const size_t n_max_iterations,
+        const unsigned char *random_seed32
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4) SECP256K1_ARG_NONNULL(7);
+
+/** Surjection proof destroy function
+ *  deallocates the struct that was allocated with secp256k1_surjectionproof_allocate_initialized
+ *
+ * In:               proof: pointer to secp256k1_surjectionproof struct
+ */
+SECP256K1_API void secp256k1_surjectionproof_destroy(
+        secp256k1_surjectionproof* proof
+) SECP256K1_ARG_NONNULL(1);
 
 /** Surjection proof generation function
  * Returns 0: proof could not be created

--- a/src/modules/surjection/main_impl.h
+++ b/src/modules/surjection/main_impl.h
@@ -151,6 +151,37 @@ static size_t secp256k1_surjectionproof_csprng_next(secp256k1_surjectionproof_cs
     }
 }
 
+/* XXX secp256k1_surjectionproof_create is not a good name, because it can be confused with secp256k1_surjectionproof_generate */
+int secp256k1_surjectionproof_allocate_initialized(const secp256k1_context* ctx, secp256k1_surjectionproof** proof_out_p, size_t *input_index, const secp256k1_fixed_asset_tag* fixed_input_tags, const size_t n_input_tags, const size_t n_input_tags_to_use, const secp256k1_fixed_asset_tag* fixed_output_tag, const size_t n_max_iterations, const unsigned char *random_seed32) {
+    int ret = 0;
+    secp256k1_surjectionproof* proof;
+
+    VERIFY_CHECK(ctx != NULL);
+
+    ARG_CHECK(proof_out_p != NULL);
+    *proof_out_p = 0;
+
+    proof = (secp256k1_surjectionproof*)checked_malloc(&ctx->error_callback, sizeof(secp256k1_surjectionproof));
+    if (proof != NULL) {
+        ret = secp256k1_surjectionproof_initialize(ctx, proof, input_index, fixed_input_tags, n_input_tags, n_input_tags_to_use, fixed_output_tag, n_max_iterations, random_seed32);
+        if (ret) {
+            *proof_out_p = proof;
+        }
+        else {
+            free(proof);
+        }
+    }
+    return ret;
+}
+
+/* XXX add checks to prevent destroy of stack-allocated struct ? */
+void secp256k1_surjectionproof_destroy(secp256k1_surjectionproof* proof) {
+    if (proof != NULL) {
+        VERIFY_CHECK(proof->n_inputs <= SECP256K1_SURJECTIONPROOF_MAX_N_INPUTS);
+        free(proof);
+    }
+}
+
 int secp256k1_surjectionproof_initialize(const secp256k1_context* ctx, secp256k1_surjectionproof* proof, size_t *input_index, const secp256k1_fixed_asset_tag* fixed_input_tags, const size_t n_input_tags, const size_t n_input_tags_to_use, const secp256k1_fixed_asset_tag* fixed_output_tag, const size_t n_max_iterations, const unsigned char *random_seed32) {
     secp256k1_surjectionproof_csprng csprng;
     size_t n_iterations = 0;


### PR DESCRIPTION
Relevant issue: #36 

This is working, but not yet finished. I am asking for review and  comments.

In particular, I am not sure about naming for the functions.

naming allocation function `secp256k1_surjectionproof_create`, to be in line with the `secp256k1_scratch_space_create`, have a problem that this might get confused with `secp256k1_surjectionproof_generate` - completely different function, but the meanings for the words 'create' and 'generate' are close.

I decided to use the name `secp256k1_surjectionproof_allocate_initialized` - literally what the function would do.

At the same time, for the deallocation function, I used 'destroy' (`secp256k1_surjectionproof_destroy`), because it is used for this meaning in other places.

Other concern what I want to request comments on, is that `secp256k1_surjectionproof_destroy` can potentially be called on stack-allocated struct, with bad consequences. It may be good idea to use some sort of marker bytes to distinguish stack/heap allocated structs, and if there is a mixup, then die cleanly, to prevent possible abuse. The marker bytes could be set within `_initialize()`, and then `_allocate_initialized()` can adjust these markers slightly, so other checking code would treat them as valid, but `_destroy()` would be able to easily distinguish between stack and heap allocated struct. But this change would mean the scope of this PR would extend to `_initialize()` function. Maybe the concern is not that big to warrant changes in `_initialize()`.

