### PR TITLE
Clarify how to derive alternative generator H

### DIFF
--- a/src/modules/rangeproof/main_impl.h
+++ b/src/modules/rangeproof/main_impl.h
@@ -15,9 +15,14 @@
 
 /** Alternative generator for secp256k1.
  *  This is the sha256 of 'g' after DER encoding (without compression),
- *  which happens to be a point on the curve.
- *  sage: G2 = EllipticCurve ([F (0), F (7)]).lift_x(F(int(hashlib.sha256('0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8'.decode('hex')).hexdigest(),16)))
- *  sage: '%x %x' % G2.xy()
+ *  which happens to be a point on the curve. More precisely, the generator is
+ *  derived by running the following script with the sage mathematics software.
+
+    import hashlib
+    F = FiniteField (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F)
+    G_DER = '0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8'
+    G2 = EllipticCurve ([F (0), F (7)]).lift_x(F(int(hashlib.sha256(G_DER.decode('hex')).hexdigest(),16)))
+    print('%x %x' % G2.xy())
  */
 static const secp256k1_generator secp256k1_generator_h_internal = {{
     0x50, 0x92, 0x9b, 0x74, 0xc1, 0xa0, 0x49, 0x54, 0xb7, 0x8b, 0x4b, 0x60, 0x35, 0xe9, 0x7a, 0x5e,


### PR DESCRIPTION
I'm suggesting to link to this procedure from the taproot BIP (https://github.com/sipa/bips/pull/43) to create a internal taproot key without known dlog. Importing hashlib and defining F are necessary to just copy and paste and run this.