### PR TITLE
Add $(COMMON_LIB) to exhaustive tests to fix ARM asm build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -115,7 +115,7 @@ exhaustive_tests_CPPFLAGS = -DSECP256K1_BUILD -I$(top_srcdir)/src $(SECP_INCLUDE
 if !ENABLE_COVERAGE
 exhaustive_tests_CPPFLAGS += -DVERIFY
 endif
-exhaustive_tests_LDADD = $(SECP_LIBS)
+exhaustive_tests_LDADD = $(SECP_LIBS) $(COMMON_LIB)
 exhaustive_tests_LDFLAGS = -static
 TESTS += exhaustive_tests
 endif


### PR DESCRIPTION
port of https://github.com/bitcoin-core/secp256k1/pull/597, this is necessary to run the tests on ARM