### PR TITLE
Add tweak32 parameter to musig_partial_sig_combine

### DIFF
--- a/include/secp256k1_musig.h
+++ b/include/secp256k1_musig.h
@@ -366,13 +366,20 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_musig_partial_sig_verif
  *  Out:          sig: complete signature (cannot be NULL)
  *  In:  partial_sigs: array of partial signatures to combine (cannot be NULL)
  *             n_sigs: number of signatures in the partial_sigs array
+ *            tweak32: if `combined_pk` was tweaked with `ec_pubkey_tweak_add` after
+ *                     `musig_pubkey_combine` and before `musig_session_initialize` then
+ *                     the same tweak must be provided here in order to get a valid
+ *                     signature for the tweaked key. Otherwise `tweak` should be NULL.
+ *                     If the tweak is larger than the group order or 0 this function will
+ *                     return 0. (can be NULL)
  */
 SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_musig_partial_sig_combine(
     const secp256k1_context* ctx,
     const secp256k1_musig_session *session,
     secp256k1_schnorrsig *sig,
     const secp256k1_musig_partial_signature *partial_sigs,
-    size_t n_sigs
+    size_t n_sigs,
+    const unsigned char *tweak32
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
 /** Converts a partial signature to an adaptor signature by adding a given secret

--- a/src/modules/musig/example.c
+++ b/src/modules/musig/example.c
@@ -119,7 +119,7 @@ int sign(const secp256k1_context* ctx, unsigned char seckeys[][32], const secp25
             }
         }
     }
-    return secp256k1_musig_partial_sig_combine(ctx, &musig_session[0], sig, partial_sig, N_SIGNERS);
+    return secp256k1_musig_partial_sig_combine(ctx, &musig_session[0], sig, partial_sig, N_SIGNERS, NULL);
 }
 
  int main(void) {


### PR DESCRIPTION
With this PR it's possible to create MuSig signatures for public keys with pay to contract commitments:

```
secp256k1_musig_pubkey_combine(.., &P, pk_hash, pk, ...);
secp256k1_ec_pubkey_tweak_add(ctx, &Q, ec_commit_tweak);
/* Note same pk_hash as in pubkey combine but with tweaked key Q */
secp256k1_musig_session_initialize(..., &Q, pk_hash, ...);
...
secp256k1_musig_partial_sig_combine(..., ec_commit_tweak);
```

If the signers want to create a signature for the the normal combined key `P` they run the protocol just as before (i.e. initialize the session with `P` and give `NULL` to the `partial_sig_combine` `tweak32` argument.
