### PR TITLE
musig: fix session_init argument NULL check

### DIFF
--- a/include/secp256k1_musig.h
+++ b/include/secp256k1_musig.h
@@ -241,7 +241,7 @@ SECP256K1_API int secp256k1_musig_session_init(
     const secp256k1_musig_pre_session *pre_session,
     size_t n_signers,
     const unsigned char *seckey
-) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4) SECP256K1_ARG_NONNULL(5) SECP256K1_ARG_NONNULL(7) SECP256K1_ARG_NONNULL(8) SECP256K1_ARG_NONNULL(11);
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4) SECP256K1_ARG_NONNULL(5) SECP256K1_ARG_NONNULL(7) SECP256K1_ARG_NONNULL(8) SECP256K1_ARG_NONNULL(10);
 
 /** Gets the signer's public nonce given a list of all signers' data with
  *  commitments.  Called by participating signers after


### PR DESCRIPTION
Fixes #141 