### PR TITLE
PoC: Add internals module

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -203,3 +203,8 @@ endif
 if ENABLE_MODULE_ECDSA_ADAPTOR
 include src/modules/ecdsa_adaptor/Makefile.am.include
 endif
+
+if ENABLE_MODULE_INTERNALS
+include src/modules/internals/Makefile.am.include
+endif
+

--- a/configure.ac
+++ b/configure.ac
@@ -191,6 +191,11 @@ AC_ARG_ENABLE(module_ecdsa-adaptor,
     [enable_module_ecdsa_adaptor=$enableval],
     [enable_module_ecdsa_adaptor=no])
 
+AC_ARG_ENABLE(module_internals,
+    AS_HELP_STRING([--enable-module-musig],[enable internals module (experimental)]),
+    [enable_module_internals=$enableval],
+    [enable_module_internals=no])
+
 AC_ARG_ENABLE(external_default_callbacks,
     AS_HELP_STRING([--enable-external-default-callbacks],[enable external default callback functions [default=no]]),
     [use_external_default_callbacks=$enableval],
@@ -534,6 +539,11 @@ if test x"$enable_module_ecdsa_s2c" = x"yes"; then
   AC_DEFINE(ENABLE_MODULE_ECDSA_S2C, 1, [Define this symbol to enable the ECDSA sign-to-contract module])
 fi
 
+if test x"$enable_module_internals" = x"yes"; then
+  AC_DEFINE(ENABLE_MODULE_INTERNALS, 1, [Define this symbol to enable the internals module])
+  enable_module_internals=yes
+fi
+
 if test x"$use_external_default_callbacks" = x"yes"; then
   AC_DEFINE(USE_EXTERNAL_DEFAULT_CALLBACKS, 1, [Define this symbol if an external implementation of the default callbacks is used])
 fi
@@ -563,6 +573,7 @@ if test x"$enable_experimental" = x"yes"; then
   AC_MSG_NOTICE([Building schnorrsig module: $enable_module_schnorrsig])
   AC_MSG_NOTICE([Building ECDSA sign-to-contract module: $enable_module_ecdsa_s2c])
   AC_MSG_NOTICE([Building ECDSA adaptor signatures module: $enable_module_ecdsa_adaptor])
+  AC_MSG_NOTICE([Building internals module: $enable_module_internals])
   AC_MSG_NOTICE([******])
 
 
@@ -645,6 +656,7 @@ AM_CONDITIONAL([ENABLE_MODULE_EXTRAKEYS], [test x"$enable_module_extrakeys" = x"
 AM_CONDITIONAL([ENABLE_MODULE_SCHNORRSIG], [test x"$enable_module_schnorrsig" = x"yes"])
 AM_CONDITIONAL([ENABLE_MODULE_ECDSA_S2C], [test x"$enable_module_ecdsa_s2c" = x"yes"])
 AM_CONDITIONAL([ENABLE_MODULE_ECDSA_ADAPTOR], [test x"$enable_module_ecdsa_adaptor" = x"yes"])
+AM_CONDITIONAL([ENABLE_MODULE_INTERNALS], [test x"$enable_module_internals" = x"yes"])
 AM_CONDITIONAL([USE_EXTERNAL_ASM], [test x"$use_external_asm" = x"yes"])
 AM_CONDITIONAL([USE_ASM_ARM], [test x"$set_asm" = x"arm"])
 AM_CONDITIONAL([ENABLE_MODULE_SURJECTIONPROOF], [test x"$enable_module_surjectionproof" = x"yes"])
@@ -672,6 +684,7 @@ echo "  module schnorrsig       = $enable_module_schnorrsig"
 echo "  module musig            = $enable_module_musig"
 echo "  module ecdsa-s2c        = $enable_module_ecdsa_s2c"
 echo "  module ecdsa-adaptor    = $enable_module_ecdsa_adaptor"
+echo "  module internals        = $enable_module_internals"
 echo
 echo "  asm                     = $set_asm"
 echo "  ecmult window size      = $set_ecmult_window"

--- a/include/internals/secp256k1_scalar.h
+++ b/include/internals/secp256k1_scalar.h
@@ -1,0 +1,25 @@
+#ifndef SECP256K1_INTERNALS_H
+#define SECP256K1_INTERNALS_H
+
+#include "secp256k1.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Caller is responsible for allocating a maximally-aligned space of size
+   secp256k1_internals_scalar_size */
+typedef struct secp256k1_internals_scalar_struct secp256k1_internals_scalar;
+
+SECP256K1_API size_t secp256k1_internals_scalar_size(void);
+
+SECP256K1_API void secp256k1_internals_scalar_set_b32(secp256k1_internals_scalar *r, const unsigned char *bin, int *overflow);
+
+SECP256K1_API void secp256k1_internals_scalar_get_b32(unsigned char *bin, const secp256k1_internals_scalar* a);
+
+SECP256K1_API int secp256k1_internals_scalar_add(secp256k1_internals_scalar *r, const secp256k1_internals_scalar *a, const secp256k1_internals_scalar *b);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/modules/internals/Makefile.am.include
+++ b/src/modules/internals/Makefile.am.include
@@ -1,0 +1,4 @@
+include_HEADERS += include/internals/secp256k1_scalar.h
+noinst_HEADERS += src/modules/internals/main_impl.h
+noinst_HEADERS += src/modules/internals/scalar_impl.h
+noinst_HEADERS += src/modules/internals/tests_impl.h

--- a/src/modules/internals/main_impl.h
+++ b/src/modules/internals/main_impl.h
@@ -1,0 +1,13 @@
+/**********************************************************************
+ * Copyright (c) 2021 Jonas Nick                                      *
+ * Distributed under the MIT software license, see the accompanying   *
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ **********************************************************************/
+#ifndef _SECP256K1_MODULE_INTERNALS_MAIN_
+#define _SECP256K1_MODULE_INTERNALS_MAIN_
+#include "include/secp256k1.h"
+#include "include/internals/secp256k1_scalar.h"
+
+#include "scalar_impl.h"
+
+#endif

--- a/src/modules/internals/scalar_impl.h
+++ b/src/modules/internals/scalar_impl.h
@@ -1,0 +1,32 @@
+/***********************************************************************
+ * Copyright (c) 2021 Jonas Nick                                       *
+ * Distributed under the MIT software license, see the accompanying    *
+ * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
+ ***********************************************************************/
+
+#ifndef SECP256K1_MODULE_INTERNALS_SCALAR_IMPL
+#define SECP256K1_MODULE_INTERNALS_SCALAR_IMPL
+
+#include "scalar.h"
+
+struct secp256k1_internals_scalar_struct {
+    secp256k1_scalar s;
+};
+
+size_t secp256k1_internals_scalar_size() {
+    return sizeof(struct secp256k1_internals_scalar_struct);
+}
+
+void secp256k1_internals_scalar_set_b32(secp256k1_internals_scalar *r, const unsigned char *bin, int *overflow) {
+    secp256k1_scalar_set_b32(&r->s, bin, overflow);
+}
+
+void secp256k1_internals_scalar_get_b32(unsigned char *bin, const secp256k1_internals_scalar* a) {
+    secp256k1_scalar_get_b32(bin, &a->s);
+}
+
+int secp256k1_internals_scalar_add(secp256k1_internals_scalar *r, const secp256k1_internals_scalar *a, const secp256k1_internals_scalar *b) {
+    return secp256k1_scalar_add(&r->s, &a->s, &b->s);
+}
+
+#endif

--- a/src/modules/internals/tests_impl.h
+++ b/src/modules/internals/tests_impl.h
@@ -1,0 +1,32 @@
+/***********************************************************************
+ * Copyright (c) 2021  Jonas Nick                                      *
+ * Distributed under the MIT software license, see the accompanying    *
+ * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
+ ***********************************************************************/
+
+#ifndef SECP256K1_MODULE_INTERNALS_TESTS_H
+#define SECP256K1_MODULE_INTERNALS_TESTS_H
+
+#include "internals/secp256k1_scalar.h"
+
+void test_internals_scalar(void) {
+    secp256k1_internals_scalar *scalar;
+    unsigned char buf_a[32], buf_b[32];
+
+    scalar = malloc(secp256k1_internals_scalar_size());
+    CHECK(scalar != NULL);
+    memset(buf_a, 0, sizeof(buf_a));
+    buf_a[0] = 1;
+    secp256k1_internals_scalar_set_b32(scalar, buf_a, NULL);
+    secp256k1_internals_scalar_add(scalar, scalar, scalar);
+    secp256k1_internals_scalar_get_b32(buf_b, scalar);
+    buf_a[0] = 2;
+    CHECK(memcmp(buf_a, buf_b, 32) == 0);
+    free(scalar);
+}
+
+void run_internals_tests(void) {
+    test_internals_scalar();
+}
+
+#endif /* SECP256K1_MODULE_INTERNALS_TESTS_H */

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -884,3 +884,8 @@ int secp256k1_tagged_sha256(const secp256k1_context* ctx, unsigned char *hash32,
 # include "modules/surjection/main_impl.h"
 #endif
 
+#ifdef ENABLE_MODULE_INTERNALS
+# include "modules/internals/main_impl.h"
+#endif
+
+

--- a/src/tests.c
+++ b/src/tests.c
@@ -6753,6 +6753,10 @@ void run_ecdsa_openssl(void) {
 # include "modules/ecdsa_adaptor/tests_impl.h"
 #endif
 
+#ifdef ENABLE_MODULE_INTERNALS
+# include "modules/internals/tests_impl.h"
+#endif
+
 void run_secp256k1_memczero_test(void) {
     unsigned char buf1[6] = {1, 2, 3, 4, 5, 6};
     unsigned char buf2[sizeof(buf1)];
@@ -7070,6 +7074,10 @@ int main(int argc, char **argv) {
 
 #ifdef ENABLE_MODULE_ECDSA_ADAPTOR
     run_ecdsa_adaptor_tests();
+#endif
+
+#ifdef ENABLE_MODULE_INTERNALS
+    run_internals_tests();
 #endif
 
     /* util tests */


### PR DESCRIPTION
The idea with exposing internal functions is that instead of (only) having experimental modules, we could have experimental _libraries_ that depend on libsecp and live outside of this repo. This has a couple of advantages, such as being able to phase out experimental modules, which simplifies versioning. One downside, however, is that the benefits of libsecp being a single compilation unit is being lost. But another big benefit is that complicated, stateful protocols (such as threshold sigs) can be written in rust (for example), using libsecp internals.

I only played with exposing scalars so far, but the module could also provide `field.h`, `group.h`, `ecmult`, `ecmult_gen`, etc. It would have no API or ABI guarantees. One idea mentioned by @rustyrussell is to make each call fail unless secp256k1_experimental_enable(version) has been called (with the exact version of the library).