### PR TITLE
whitelist: remove ability to specific nonce function

### DIFF
--- a/include/secp256k1_whitelist.h
+++ b/include/secp256k1_whitelist.h
@@ -101,8 +101,6 @@ SECP256K1_API int secp256k1_whitelist_signature_serialize(
  *         online_seckey: the secret key to the signer's online pubkey
  *         summed_seckey: the secret key to the sum of (whitelisted key, signer's offline pubkey)
  *         index: the signer's index in the lists of keys
- *         noncefp:pointer to a nonce generation function. If NULL, secp256k1_nonce_function_default is used
- *         ndata:  pointer to arbitrary data used by the nonce generation function (can be NULL)
  * Out:    sig: The produced signature.
  *
  * The signatures are of the list of all passed pubkeys in the order
@@ -120,10 +118,8 @@ SECP256K1_API int secp256k1_whitelist_sign(
   const size_t n_keys,
   const secp256k1_pubkey *sub_pubkey,
   const unsigned char *online_seckey,
-  const unsigned char *summed_seckey,
-  const size_t index,
-  secp256k1_nonce_function noncefp,
-  const void *noncedata
+  const unsigned char *summed_seckeyx,
+  const size_t index
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4) SECP256K1_ARG_NONNULL(6) SECP256K1_ARG_NONNULL(7) SECP256K1_ARG_NONNULL(8);
 
 /** Verify a whitelist signature

--- a/src/bench_whitelist.c
+++ b/src/bench_whitelist.c
@@ -39,7 +39,7 @@ static void bench_whitelist(void* arg, int iters) {
 static void bench_whitelist_setup(void* arg) {
     bench_data* data = (bench_data*)arg;
     int i = 0;
-    CHECK(secp256k1_whitelist_sign(data->ctx, &data->sig, data->online_pubkeys, data->offline_pubkeys, data->n_keys, &data->sub_pubkey, data->online_seckey[i], data->summed_seckey[i], i, NULL, NULL));
+    CHECK(secp256k1_whitelist_sign(data->ctx, &data->sig, data->online_pubkeys, data->offline_pubkeys, data->n_keys, &data->sub_pubkey, data->online_seckey[i], data->summed_seckey[i], i));
 }
 
 static void run_test(bench_data* data, int iters) {

--- a/src/modules/whitelist/main_impl.h
+++ b/src/modules/whitelist/main_impl.h
@@ -12,16 +12,12 @@
 
 #define MAX_KEYS SECP256K1_WHITELIST_MAX_N_KEYS  /* shorter alias */
 
-int secp256k1_whitelist_sign(const secp256k1_context* ctx, secp256k1_whitelist_signature *sig, const secp256k1_pubkey *online_pubkeys, const secp256k1_pubkey *offline_pubkeys, const size_t n_keys, const secp256k1_pubkey *sub_pubkey, const unsigned char *online_seckey, const unsigned char *summed_seckey, const size_t index, secp256k1_nonce_function noncefp, const void *noncedata) {
+int secp256k1_whitelist_sign(const secp256k1_context* ctx, secp256k1_whitelist_signature *sig, const secp256k1_pubkey *online_pubkeys, const secp256k1_pubkey *offline_pubkeys, const size_t n_keys, const secp256k1_pubkey *sub_pubkey, const unsigned char *online_seckey, const unsigned char *summed_seckey, const size_t index) {
     secp256k1_gej pubs[MAX_KEYS];
     secp256k1_scalar s[MAX_KEYS];
     secp256k1_scalar sec, non;
     unsigned char msg32[32];
     int ret;
-
-    if (noncefp == NULL) {
-        noncefp = secp256k1_nonce_function_default;
-    }
 
     /* Sanity checks */
     VERIFY_CHECK(ctx != NULL);
@@ -53,7 +49,7 @@ int secp256k1_whitelist_sign(const secp256k1_context* ctx, secp256k1_whitelist_s
             size_t i;
             unsigned char nonce32[32];
             int done;
-            ret = noncefp(nonce32, msg32, seckey32, NULL, (void*)noncedata, count);
+            ret = secp256k1_nonce_function_default(nonce32, msg32, seckey32, NULL, NULL, count);
             if (!ret) {
                 break;
             }
@@ -67,7 +63,7 @@ int secp256k1_whitelist_sign(const secp256k1_context* ctx, secp256k1_whitelist_s
             for (i = 0; i < n_keys; i++) {
                 msg32[0] ^= i + 1;
                 msg32[1] ^= (i + 1) / 0x100;
-                ret = noncefp(&sig->data[32 * (i + 1)], msg32, seckey32, NULL, (void*)noncedata, count);
+                ret = secp256k1_nonce_function_default(&sig->data[32 * (i + 1)], msg32, seckey32, NULL, NULL, count);
                 if (!ret) {
                     break;
                 }

--- a/src/modules/whitelist/tests_impl.h
+++ b/src/modules/whitelist/tests_impl.h
@@ -15,7 +15,7 @@ void test_whitelist_end_to_end_internal(const unsigned char *summed_seckey, cons
         secp256k1_whitelist_signature sig;
         secp256k1_whitelist_signature sig1;
 
-        CHECK(secp256k1_whitelist_sign(ctx, &sig, online_pubkeys, offline_pubkeys, n_keys, sub_pubkey, online_seckey, summed_seckey, signer_i, NULL, NULL));
+        CHECK(secp256k1_whitelist_sign(ctx, &sig, online_pubkeys, offline_pubkeys, n_keys, sub_pubkey, online_seckey, summed_seckey, signer_i));
         CHECK(secp256k1_whitelist_verify(ctx, &sig, online_pubkeys, offline_pubkeys, n_keys, sub_pubkey) == 1);
         /* Check that exchanging keys causes a failure */
         CHECK(secp256k1_whitelist_verify(ctx, &sig, offline_pubkeys, online_pubkeys, n_keys, sub_pubkey) != 1);


### PR DESCRIPTION
This functionality is inappropriate to expose for a zero-knowledge proof, and was confusingly (and potentially dangerously) implemented.

For now just replace it with code that uses the default ECDSA 6979 nonce, which we at least know will do something safe with the input that this code gives it (a "message" which is a commitment to all the pubkeys involved, xor'd with the index of which `s` value we are generating, alongside the secret key and a retry count in case of overflow). In a later PR I will just replace this mess with a sanely-seeded chacha.

(Ideally in future we would be using [Merlin](https://medium.com/@hdevalence/merlin-flexible-composable-transcripts-for-zero-knowledge-proofs-28d9fda22d9a) or something but for this borderline-legacy code I think it's best not to try anything too extreme.)