### PR TITLE
Add ordinary and x-only tweaking to spec and simplify implementation

### DIFF
--- a/doc/musig-spec.mediawiki
+++ b/doc/musig-spec.mediawiki
@@ -81,18 +81,25 @@ The algorithm '''''KeySort(pk<sub>1..u</sub>)''''' is defined as:
 Input:
 * The number ''u'' of public keys with ''0 < u < 2^32''
 * The public keys ''pk<sub>1..u</sub>'': ''u'' 32-byte arrays
+* The number ''v'' of tweaks with ''0 &le; v < 2^32''
+* The tweaks ''tweak<sub>1..v</sub>'': ''v'' 32-byte arrays
+* The tweak methods ''is_xonly_t<sub>1..v</sub>'' : ''v'' booleans
 
-The algorithm '''''KeyAgg(pk<sub>1..u</sub>)''''' is defined as:
-* Let ''Q = KeyAggInternal(pk<sub>1..u</sub>)''; fail if that fails.
+The algorithm '''''KeyAgg(pk<sub>1..u</sub>, tweak<sub>1..v</sub>, is_xonly_t<sub>1..v</sub>)''''' is defined as:
+* Let ''(Q,_,_) = KeyAggInternal(pk<sub>1..u</sub>, tweak<sub>1..v</sub>, is_xonly_t<sub>1..v</sub>)''; fail if that fails.
 * Return ''bytes(Q)''.
 
-The algorithm '''''KeyAggInternal(pk<sub>1..u</sub>)''''' is defined as:
+The algorithm '''''KeyAggInternal(pk<sub>1..u</sub>, tweak<sub>1..v</sub>, is_xonly_t<sub>1..v</sub>)''''' is defined as:
 * For ''i = 1 .. u'':
 ** Let ''a<sub>i</sub> = KeyAggCoeff(pk<sub>1..u</sub>, pk<sub>i</sub>)''.
 ** Let ''P<sub>i</sub> = point(pk<sub>i</sub>)''; fail if that fails.
-* Let ''Q = a<sub>1</sub>⋅P<sub>1</sub> + a<sub>2</sub>⋅P<sub>1</sub> + ... + a<sub>u</sub>⋅P<sub>u</sub>''
-* Fail if ''is_infinite(Q)''.
-* Return ''Q''.
+* Let ''Q<sub>0</sub> = a<sub>1</sub>⋅P<sub>1</sub> + a<sub>2</sub>⋅P<sub>1</sub> + ... + a<sub>u</sub>⋅P<sub>u</sub>''
+* Fail if ''is_infinite(Q<sub>0</sub>)''.
+* Let ''tacc<sub>0</sub> = 0''
+* Let ''gacc<sub>0</sub> = 1''
+* For ''i = 1 .. v'':
+** Let ''(Q<sub>i</sub>, gacc<sub>i</sub>, tacc<sub>i</sub>) = Tweak(Q<sub>i-1</sub>, gacc<sub>i-1</sub>, tweak<sub>i</sub>, tacc<sub>i-1</sub>, is_xonly_t<sub>i</sub>)''; fail if that fails
+* Return ''(Q<sub>v</sub>, gacc<sub>v</sub>, tacc<sub>v</sub>)''.
 
 The algorithm '''''HashKeys(pk<sub>1..u</sub>)''''' is defined as:
 * Return ''hash<sub>KeyAgg list</sub>(pk<sub>1</sub> || pk<sub>2</sub> || ... || pk<sub>u</sub>)''
@@ -108,6 +115,17 @@ The algorithm '''''KeyAggCoeff(pk<sub>1..u</sub>, pk')''''' is defined as:
 * If ''IsSecond(pk<sub>1..u</sub>, pk')'':
 ** Return 1
 * Return ''int(hash<sub>KeyAgg coefficient</sub>(L || pk')) mod n''
+
+The algorithm '''''Tweak(Q<sub>i-1</sub>, gacc<sub>i-1</sub>, tweak<sub>i</sub>, tacc<sub>i-1</sub>, is_xonly_t<sub>i</sub>)''''' is defined as:
+* If ''is_xonly_t<sub>i</sub>'' and ''not has_even_y(Q<sub>i-1</sub>)'':
+** Let ''g<sub>i-1</sub> = -1 mod n''
+* Else: let ''g<sub>i-1</sub> = 1''
+* Let ''t<sub>i</sub> = int(tweak<sub>i</sub>)''; fail if ''t &ge; n''
+* Let ''Q<sub>i</sub> = g<sub>i-1</sub>⋅Q<sub>i-1</sub> + t<sub>i</sub>⋅G''
+** Fail if ''is_infinite(Q<sub>i</sub>)''
+* Let ''gacc<sub>i</sub> = g<sub>i-1</sub>⋅gacc<sub>i-1</sub> mod n''
+* Let ''tacc<sub>i</sub> = t<sub>i</sub> + g<sub>i-1</sub>⋅tacc<sub>i-1</sub> mod n''
+* Return ''(Q<sub>i</sub>, gacc<sub>i</sub>, tacc<sub>i</sub>)''
 
 ==== Nonce Generation ====
 
@@ -137,22 +155,25 @@ The Session Context is a data structure consisting of the following elements:
 * The aggregate public nonce ''aggnonce'': a 66-byte array
 * The number ''u'' of public keys with ''0 < u < 2^32''
 * The public keys ''pk<sub>1..u</sub>'': ''u'' 32-byte arrays
+* The number ''v'' of tweaks with ''0 &le; v < 2^32''
+* The tweaks ''tweak<sub>1..v</sub>'': ''v'' 32-byte arrays
+* The tweak methods ''is_xonly_t<sub>1..v</sub>'' : ''v'' booleans
 * The message ''m'': a 32-byte array
 
-We write "Let ''(aggnonce, u, pk<sub>1..u</sub>, m) = session_ctx''" to assign names to the elements of a Session Context.
+We write "Let ''(aggnonce, u, pk<sub>1..u</sub>, v, tweak<sub>1..v</sub>, is_xonly_t<sub>1..v</sub>, m) = session_ctx''" to assign names to the elements of a Session Context.
 
 The algorithm '''''GetSessionValues(session_ctx)''''' is defined as:
-* Let ''(aggnonce, u, pk<sub>1..u</sub>, m) = session_ctx''
-* Let ''Q = KeyAggInternal(pk<sub>1..u</sub>)''; fail if that fails
+* Let ''(aggnonce, u, pk<sub>1..u</sub>, v, tweak<sub>1..v</sub>, is_xonly_t<sub>1..v</sub>, m) = session_ctx''
+* Let ''(Q, gacc<sub>v</sub>, tacc<sub>v</sub>) = KeyAggInternal(pk<sub>1..u</sub>, tweak<sub>1..v</sub>, is_xonly_t<sub>1..v</sub>)''; fail if that fails
 * Let ''b = int(hash<sub>MuSig/noncecoef</sub>(aggnonce || bytes(Q) || m)) mod n''
 * Let ''R<sub>1</sub> = pointc(aggnonce[0:33]), R<sub>2</sub> = pointc(aggnonce[33:66])''; fail if that fails
 * Let ''R = R<sub>1</sub> + b⋅R<sub>2</sub>''
 * Fail if ''is_infinite(R)''
 * Let ''e = int(hash<sub>BIP0340/challenge</sub>(bytes(R) || bytes(Q) || m)) mod n''
-* Return ''(Q, b, R, e)''
+* Return ''(Q, gacc<sub>v</sub>, tacc<sub>v</sub>, b, R, e)''
 
 The algorithm '''''GetSessionKeyAggCoeff(session_ctx, P)''''' is defined as:
-* Let ''(_, u, pk<sub>1..u</sub>, _) = session_ctx''
+* Let ''(_, u, pk<sub>1..u</sub>, _, _, _, _) = session_ctx''
 * Return ''KeyAggCoeff(pk<sub>1..u</sub>, bytes(P))''
 
 ==== Signing ====
@@ -163,7 +184,7 @@ Input:
 * The ''session_ctx'': a [[#session-context|Session Context]] data structure
 
 The algorithm '''''Sign(secnonce, sk, session_ctx)''''' is defined as:
-* Let ''(Q, b, R, e) = GetSessionValues(session_ctx)''; fail if that fails
+* Let ''(Q, gacc<sub>v</sub>, _, b, R, e) = GetSessionValues(session_ctx)''; fail if that fails
 * Let ''k'<sub>1</sub> = int(secnonce[0:32]), k'<sub>2</sub> = int(secnonce[32:64])''
 * Fail if ''k'<sub>i</sub> = 0'' or ''k'<sub>i</sub> &ge; n'' for ''i = 1..2''
 * Let ''k<sub>1</sub> = k'<sub>1</sub>, k<sub>2</sub> = k'<sub>2</sub> '' if ''has_even_y(R)'', otherwise let ''k<sub>1</sub> = n - k'<sub>1</sub>, k<sub>2</sub> = n - k<sub>2</sub>''
@@ -171,7 +192,9 @@ The algorithm '''''Sign(secnonce, sk, session_ctx)''''' is defined as:
 * Fail if ''d' = 0'' or ''d' &ge; n''
 * Let ''P = d'⋅G''
 * Let ''mu = GetSessionKeyAggCoeff(session_ctx, P)''; fail if that fails
-* Let ''d = n - d' '' if ''has_even_y(P) `XOR` has_even_y(Q)'', otherwise let ''d = d' ''
+* Let ''g<sub>v</sub> = 1'' if ''has_even_y(Q)'', otherwise let ''g<sub>v</sub> = -1 mod n''
+* Let ''gp = 1'' if ''has_even_y(P)'', otherwise let ''gp = -1 mod n''
+* Let ''d = g<sub>v</sub>⋅gacc<sub>v</sub>⋅gp⋅d' ''
 * Let ''s = (k<sub>1</sub> + b⋅k<sub>2</sub> + e⋅mu⋅d) mod n''
 * Let ''psig = bytes(s)''
 * Let ''pubnonce = cbytes(k'<sub>1</sub>⋅G) || cbytes(k'<sub>2</sub>⋅G)''
@@ -185,12 +208,15 @@ Input:
 * The number ''u'' of public nonces and public keys with ''0 < u < 2^32''
 * The public nonces ''pubnonce<sub>1..u</sub>'': ''u'' 66-byte arrays
 * The public keys ''pk<sub>1..u</sub>'': ''u'' 32-byte arrays
+* The number ''v'' of tweaks with ''0 &le; v < 2^32''
+* The tweaks ''tweak<sub>1..v</sub>'': ''v'' 32-byte arrays
+* The tweak methods ''is_xonly_t<sub>1..v</sub>'' : ''v'' booleans
 * The message ''m'': a 32-byte array
 * The index of the signer ''i'' in the public nonces and public keys with ''0 < i &le; u''
 
-The algorithm '''''PartialSigVerify(psig, pubnonce<sub>1..u</sub>, pk<sub>1..u</sub>, m, i)''''' is defined as:
+The algorithm '''''PartialSigVerify(psig, pubnonce<sub>1..u</sub>, pk<sub>1..u</sub>, tweak<sub>1..v</sub>, is_xonly_t<sub>1..v</sub>, m, i)''''' is defined as:
 * Let ''aggnonce = NonceAgg(pubnonce<sub>1..u</sub>)''; fail if that fails
-* Let ''session_ctx = (aggnonce, u, pk<sub>1..u</sub>, m)''
+* Let ''session_ctx = (aggnonce, u, pk<sub>1..u</sub>, v, tweak<sub>1..v</sub>, is_xonly_t<sub>1..v</sub>, m)''
 * Run ''PartialSigVerifyInternal(psig, pubnonce<sub>i</sub>, pk<sub>i</sub>, session_ctx)''
 * Return success iff no failure occurred before reaching this point.
 
@@ -203,13 +229,14 @@ Input:
 * The ''session_ctx'': a [[#session-context|Session Context]] data structure
 
 The algorithm '''''PartialSigVerifyInternal(psig, pubnonce, pk<sup>*</sup>, session_ctx)''''' is defined as:
-* Let ''(Q, b, R, e) = GetSessionValues(session_ctx)''; fail if that fails
+* Let ''(Q, gacc<sub>v</sub>, _, b, R, e) = GetSessionValues(session_ctx)''; fail if that fails
 * Let ''s = int(psig)''; fail if ''s &ge; n''
 * Let ''R<sup>*</sup><sub>1</sub> = pointc(pubnonce[0:33]), R<sup>*</sup><sub>2</sub> = pointc(pubnonce[33:66])''
 * Let ''R<sup>*</sup>' = R<sup>*</sup><sub>1</sub> + b⋅R<sup>*</sup><sub>2</sub>''
 * Let ''R<sup>*</sup> = R<sup>*</sup>' '' if ''has_even_y(R)'', otherwise let ''R<sup>*</sup> = -R<sup>*</sup>' ''
-* Let ''P' = point(pk<sup>*</sup>)''; fail if that fails
-* Let ''P = P' '' if ''has_even_y(Q)'', otherwise let ''P = -P' ''
+* Let ''g<sub>v</sub> = 1'' if ''has_even_y(Q)'', otherwise let ''g<sub>v</sub> = -1 mod n''
+* Let ''g' = g<sub>v</sub>⋅gacc<sub>v</sub> mod n''
+* Let ''P = g'⋅point(pk<sup>*</sup>)''; fail if that fails
 * Let ''mu = GetSessionKeyAggCoeff(session_ctx, P)''; fail if that fails
 * Fail if ''s⋅G &ne; R<sup>*</sup> + e⋅mu⋅P''
 * Return success iff no failure occurred before reaching this point.
@@ -222,15 +249,16 @@ Input:
 * The ''session_ctx'': a [[#session-context|Session Context]] data structure
 
 The algorithm '''''PartialSigAgg(psig<sub>1..u</sub>, session_ctx)''''' is defined as:
-* Let ''(_, _, R, _) = GetSessionValues(session_ctx)''; fail if that fails
+* Let ''(Q, _, tacc<sub>v</sub>, _, _, R, e) = GetSessionValues(session_ctx)''; fail if that fails
 * For ''i = 1 .. u'':
 ** Let ''s<sub>i</sub> = int(psig<sub>i</sub>)''; fail if ''s<sub>i</sub> &ge; n''.
-* Let ''s = s<sub>1</sub> + ... + s<sub>u</sub> mod n''
+* Let ''g<sub>v</sub> = 1'' if ''has_even_y(Q)'', otherwise let ''g<sub>v</sub> = -1 mod n''
+* Let ''s = s<sub>1</sub> + ... + s<sub>u</sub> + e⋅g<sub>v</sub>⋅tacc<sub>v</sub> mod n''
 * Return ''sig = ''bytes(R) || bytes(s)''
 
 === Signing Flow ===
 
-Note that this specification unnecessarily recomputes intermediary values (such as the aggregate public key) that can be cached in real implementations.
+Note that this specification unnecessarily recomputes intermediary values (such as the aggregate and tweaked public key) that can be cached in real implementations.
 
 There are multiple ways to use above algorithms and arrive at a final Schnorr signature.
 One of them can be described as follows:

--- a/doc/musig-spec.mediawiki
+++ b/doc/musig-spec.mediawiki
@@ -191,11 +191,11 @@ The algorithm '''''Sign(secnonce, sk, session_ctx)''''' is defined as:
 * Let ''d' = int(sk)''
 * Fail if ''d' = 0'' or ''d' &ge; n''
 * Let ''P = d'⋅G''
-* Let ''mu = GetSessionKeyAggCoeff(session_ctx, P)''; fail if that fails
-* Let ''g<sub>v</sub> = 1'' if ''has_even_y(Q)'', otherwise let ''g<sub>v</sub> = -1 mod n''
+* Let ''a = GetSessionKeyAggCoeff(session_ctx, P)''; fail if that fails
 * Let ''gp = 1'' if ''has_even_y(P)'', otherwise let ''gp = -1 mod n''
-* Let ''d = g<sub>v</sub>⋅gacc<sub>v</sub>⋅gp⋅d' ''
-* Let ''s = (k<sub>1</sub> + b⋅k<sub>2</sub> + e⋅mu⋅d) mod n''
+* Let ''g<sub>v</sub> = 1'' if ''has_even_y(Q)'', otherwise let ''g<sub>v</sub> = -1 mod n''
+* <div id="Sign negation"></div>Let ''d = g<sub>v</sub>⋅gacc<sub>v</sub>⋅gp⋅d' '' (See [[negation-of-the-secret-key-when-signing|Negation Of The Secret Key When Signing]])
+* Let ''s = (k<sub>1</sub> + b⋅k<sub>2</sub> + e⋅a⋅d) mod n''
 * Let ''psig = bytes(s)''
 * Let ''pubnonce = cbytes(k'<sub>1</sub>⋅G) || cbytes(k'<sub>2</sub>⋅G)''
 * If ''PartialSigVerifyInternal(psig, pubnonce, bytes(P), session_ctx)'' (see below) returns failure, abort<ref>Verifying the signature before leaving the signer prevents random or attacker provoked computation errors. This prevents publishing invalid signatures which may leak information about the secret key. It is recommended, but can be omitted if the computation cost is prohibitive.</ref>.
@@ -236,9 +236,9 @@ The algorithm '''''PartialSigVerifyInternal(psig, pubnonce, pk<sup>*</sup>, sess
 * Let ''R<sup>*</sup> = R<sup>*</sup>' '' if ''has_even_y(R)'', otherwise let ''R<sup>*</sup> = -R<sup>*</sup>' ''
 * Let ''g<sub>v</sub> = 1'' if ''has_even_y(Q)'', otherwise let ''g<sub>v</sub> = -1 mod n''
 * Let ''g' = g<sub>v</sub>⋅gacc<sub>v</sub> mod n''
-* Let ''P = g'⋅point(pk<sup>*</sup>)''; fail if that fails
-* Let ''mu = GetSessionKeyAggCoeff(session_ctx, P)''; fail if that fails
-* Fail if ''s⋅G &ne; R<sup>*</sup> + e⋅mu⋅P''
+* <div id="SigVerify negation"></div>Let ''P = g'⋅point(pk<sup>*</sup>)''; fail if that fails (See [[#negation-of-the-public-key-when-partially-verifying|Negation Of The Public Key When Partially Verifying]])
+* Let ''a = GetSessionKeyAggCoeff(session_ctx, P)''; fail if that fails
+* Fail if ''s⋅G &ne; R<sup>*</sup> + e⋅a⋅P''
 * Return success iff no failure occurred before reaching this point.
 
 ==== Partial Signature Aggregation ====
@@ -287,6 +287,90 @@ The algorithm '''''OrdinaryTweak(P, t)''''' is defined as:
 
 The algorithm '''''XonlyTweak(P, t)''''' is defined as:
 * Return ''with_even_y(P) + t⋅G''
+
+==== Negation Of The Secret Key When Signing ====
+
+In order to produce a partial signature for an x-only public key that is an aggregate of ''u'' x-only keys and tweaked ''v'' times (x-only or ordinarily), the ''[[#Sign negation|Sign]]'' algorithm may need to negate the secret key during the signing process.
+
+<poem>
+The following public keys arise as intermediate steps in the MuSig protocol:
+• ''P<sub>i</sub>'' as computed in ''KeyAggInternal'' is the point corresponding to the ''i''-th signer's x-only public key. Defining ''d'<sub>i</sub>'' to be the ''d' '' value as computed in the ''Sign'' algorithm of the ''i''-th signer, we have
+    ''P<sub>i</sub> = with_even_y(d'<sub>i</sub>⋅G) ''.
+• ''Q<sub>0</sub>'' is an aggregate of the signer's public keys and defined in ''KeyAggInternal''  as
+    ''Q<sub>0</sub> = a<sub>1</sub>⋅P<sub>1</sub> + a<sub>2</sub>⋅P<sub>1</sub> + ... + a<sub>u</sub>⋅P<sub>u</sub>''.
+• ''Q<sub>i</sub>'' as computed in ''Tweak'' for ''1 &le; i &le; v'' is the tweaked public key after the ''i''-th tweaking operation. It holds that
+    ''Q<sub>i</sub> = f(i-1) + t<sub>i</sub>⋅G'' for ''i = 1, ..., v'' where
+        ''f(i) := with_even_y(Q<sub>i</sub>)'' if ''is_xonly_t<sub>i+1</sub>'' and
+        ''f(i) := Q<sub>i</sub>'' otherwise.
+</poem>
+
+The goal is to produce a partial signature corresponding to the output of ''KeyAgg'', i.e., the final (x-only) public key point after ''v'' tweaking operations ''with_even_y(Q<sub>v</sub>)''.
+
+<poem>
+We define ''gp<sub>i</sub>'' for ''1 &le; i &le; u'' to be ''gp '' as computed in the ''Sign'' algorithm of the ''i''-th signer. It holds that
+    ''P<sub>i</sub> = gp<sub>i</sub>⋅d'<sub>i</sub>⋅G''.
+
+For ''0 &le; i &le; v-1'', the ''Tweak'' algorithm called from ''KeyAggInternal'' sets ''g<sub>i</sub>'' to ''-1 mod n'' if and only if ''is_xonly_t<sub>i+1</sub>'' is true and ''Q<sub>i</sub>'' has an odd Y coordinate. Therefore, we have
+    ''f(i) = g<sub>i</sub>⋅Q<sub>i</sub>'' for ''0 &le; i &le; v - 1''.
+
+Furthermore, the ''Sign'' and ''PartialSigVerify'' algorithms set ''g<sub>v</sub>'' such that
+    ''with_even_y(Q<sub>v</sub>) = g<sub>v</sub>⋅Q<sub>v</sub>''.
+</poem>
+
+<poem>
+So, the (x-only) final public key is
+    ''with_even_y(Q<sub>v</sub>)
+        = g<sub>v</sub>⋅Q<sub>v</sub>
+        = g<sub>v</sub>⋅(f(v-1) + t<sub>v</sub>⋅G)
+        = g<sub>v</sub>⋅(g<sub>v-1</sub>⋅(f(v-2) + t<sub>v-1</sub>⋅G) + t<sub>v</sub>⋅G)
+        = g<sub>v</sub>⋅g<sub>v-1</sub>⋅f(v-2) + g<sub>v</sub>⋅(t<sub>v</sub> + g<sub>v-1</sub>⋅t<sub>v-1</sub>)⋅G
+        = g<sub>v</sub>⋅g<sub>v-1</sub>⋅f(v-2) + (sum<sub>i=v-1..v</sub> t<sub>i</sub>⋅prod<sub>j=i..v</sub> g<sub>j</sub>)⋅G
+        = g<sub>v</sub>⋅g<sub>v-1</sub>⋅...⋅g<sub>1</sub>⋅f(0) + (sum<sub>i=1..v</sub> t<sub>i</sub>⋅prod<sub>j=i..v</sub> g<sub>j</sub>)⋅G
+        = g<sub>v</sub>⋅...⋅g<sub>0</sub>⋅Q<sub>0</sub> + g<sub>v</sub>⋅tacc<sub>v</sub>⋅G''
+    where ''tacc<sub>i</sub>'' is computed by ''KeyAggInternal'' and ''Tweak'' as follows:
+      ''tacc<sub>0</sub> = 0
+      tacc<sub>i</sub> = t<sub>i</sub> + g<sub>i-1</sub>⋅tacc<sub>i-1</sub> for i=1..v mod n''
+    for which it holds that ''g<sub>v</sub>⋅tacc<sub>v</sub> = sum<sub>i=1..v</sub> t<sub>i</sub>⋅prod<sub>j=i..v</sub> g<sub>j</sub>''.
+</poem>
+
+<poem>
+''KeyAggInternal'' and ''Tweak'' compute
+    ''gacc<sub>0</sub> = 1
+    gacc<sub>i</sub> = g<sub>i-1</sub>⋅gacc<sub>i-1</sub> for i=1..v mod n''
+So we can rewrite above equation for the final public key as
+  ''with_even_y(Q<sub>v</sub>) = g<sub>v</sub>⋅gacc<sub>v</sub>⋅Q<sub>0</sub> + g<sub>v</sub>⋅tacc<sub>v</sub>⋅G''.
+</poem>
+
+<poem>
+Then we have
+    ''with_even_y(Q<sub>v</sub>) - g<sub>v</sub>⋅tacc<sub>v</sub>⋅G
+        = g<sub>v</sub>⋅gacc<sub>v</sub>⋅Q<sub>0</sub>
+        = g<sub>v</sub>⋅gacc<sub>v</sub>⋅(a<sub>1</sub>⋅P<sub>1</sub> + ... + a<sub>u</sub>⋅P<sub>u</sub>)
+        = g<sub>v</sub>⋅gacc<sub>v</sub>⋅(a<sub>1</sub>⋅gp<sub>1</sub>⋅d'<sub>1</sub>⋅G + ... + a<sub>u</sub>⋅gp<sub>u</sub>⋅d'<sub>u</sub>⋅G)
+        = sum<sub>i=1..u</sub>(g<sub>v</sub>⋅gacc<sub>v</sub>⋅gp<sub>i</sub>⋅a<sub>i</sub>⋅d'<sub>i</sub>)*G''.
+</poem>
+
+Thus, signer ''i'' multiplies its secret key ''d'<sub>i</sub>'' with ''g<sub>v</sub>⋅gacc<sub>v</sub>⋅gp<sub>i</sub>'' in the ''[[#Sign negation|Sign]]'' algorithm.
+
+==== Negation Of The Public Key When Partially Verifying ====
+
+<poem>
+As explained in [[#negation-of-the-secret-key-when-signing|Negation Of The Secret Key When Signing]] the signer uses a possibly negated secret key
+    ''d = g<sub>v</sub>⋅gacc<sub>v</sub>⋅gp⋅d' mod n''
+when producing a partial signature to ensure that the aggregate signature will correspond to an aggregate public key with even Y coordinate.
+</poem>
+
+<poem>
+The ''[[#SigVerify negation|PartialSigVerifyInternal]]'' algorithm is supposed to check
+  ''s⋅G = R<sup>*</sup> + e⋅a⋅d⋅G''.
+</poem>
+
+<poem>
+The verifier doesn't have access to ''d⋅G'', but can construct it using the xonly public key ''pk<sup>*</sup>'' as follows:
+''d⋅G
+    = g<sub>v</sub>⋅gacc<sub>v</sub>⋅gp⋅d'⋅G
+    = g<sub>v</sub>⋅gacc<sub>v</sub>⋅point(pk<sup>*</sup>)''
+</poem>
 
 ==== Dealing with Infinity in Nonce Aggregation ====
 

--- a/doc/musig-spec.mediawiki
+++ b/doc/musig-spec.mediawiki
@@ -175,7 +175,7 @@ The algorithm ''Sign(secnonce, sk, aggnonce, pk<sub>1..u</sub>, m)'' is defined 
 * Let ''psig = bytes(s)''
 * Let ''pubnonce = cbytes(k'<sub>1</sub>⋅G) || cbytes(k'<sub>2</sub>⋅G)''
 * If ''PartialSigVerifyInternal(psig, pubnonce, aggnonce, pk<sub>1..u</sub>, bytes(P), m)'' (see below) returns failure, abort<ref>Verifying the signature before leaving the signer prevents random or attacker provoked computation errors. This prevents publishing invalid signatures which may leak information about the secret key. It is recommended, but can be omitted if the computation cost is prohibitive.</ref>.
-* Return partial signature ''psig
+* Return partial signature ''psig''
 
 ==== Partial Signature Verification ====
 
@@ -185,7 +185,7 @@ Input:
 * The public nonces ''pubnonce<sub>1..u</sub>'': ''u'' 66-byte arrays
 * The public keys ''pk<sub>1..u</sub>'': ''u'' 32-byte arrays
 * The message ''m'': a 32-byte array
-* The index of the signer ''i'' in the public nonces and public keys with ''0 < i <= u''
+* The index of the signer ''i'' in the public nonces and public keys with ''0 < i &le; u''
 
 The algorithm ''PartialSigVerify(psig, pubnonce<sub>1..u</sub>, pk<sub>1..u</sub>, m, i)'' is defined as:
 * Let ''aggnonce = NonceAgg(pubnonce<sub>1..u</sub>)''; fail if that fails
@@ -224,11 +224,11 @@ The algorithm ''PartialSigVerifyInternal(psig, pubnonce, aggnonce, pk<sub>1..u</
 Input:
 * The final nonce ''R'' as created during  ''Sign'' or ''PartialSigVerify'': a point
 * The number ''u'' of signatures with ''0 < u < 2^32''
-* The partial signatures ''sig<sub>1..u</sub>'': ''u'' 32-byte arrays
+* The partial signatures ''psig<sub>1..u</sub>'': ''u'' 32-byte arrays
 
-The algorithm ''SigAgg(R, sig<sub>1..u</sub>)'' is defined as:
+The algorithm ''PartialSigAgg(R, psig<sub>1..u</sub>)'' is defined as:
 * For ''i = 1 .. u'':
-** Let ''s<sub>i</sub> = int(sig<sub>i</sub>)''; fail if ''s<sub>i</sub> &ge; n''.
+** Let ''s<sub>i</sub> = int(psig<sub>i</sub>)''; fail if ''s<sub>i</sub> &ge; n''.
 * Let ''s = s<sub>1</sub> + ... + s<sub>u</sub> mod n''
 * Return ''sig = ''bytes(R) || bytes(s)''
 
@@ -241,7 +241,7 @@ One of them can be described as follows:
 The signers ''1'' to ''n'' each run ''NonceGen'' to compute ''secnonce'' and ''pubnonce''.
 Every signer sends its public key and ''pubnonce'' to every other signer and all signers agree on a single message to sign.
 Then, the signers run ''NonceAgg'' and ''Sign'' with their secret signing key and ''secnonce''.
-They send the resulting partial signature to every other signer and combine them with the ''SigAgg'' algorithm.
+They send the resulting partial signature to every other signer and combine them with the ''PartialSigAgg'' algorithm.
 
 ''IMPORTANT'': The ''Sign'' algorithm must '''not''' be executed twice with the same ''secnonce''.
 Otherwise, it is possible to extract the secret signing key from the partial signatures.

--- a/doc/musig-spec.mediawiki
+++ b/doc/musig-spec.mediawiki
@@ -1,5 +1,5 @@
 <pre>
-  Title: MuSig Key Aggregation
+  Title: MuSig
   Author:
   Status: Draft
   License: BSD-2-Clause
@@ -10,7 +10,7 @@
 
 === Abstract ===
 
-This document describes MuSig Key Aggregation in libsecp256k1-zkp.
+This document proposes a standard for the MuSig2 protocol that supports ''tweaking'' and outputs [https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki BIP340] public keys and signatures.
 
 === Copyright ===
 
@@ -65,10 +65,10 @@ The following conventions are used, with constants as defined for [https://www.s
 ==== Key Sorting ====
 
 Input:
-* The number ''u'' of signatures with ''0 < u < 2^32''
+* The number ''u'' of public keys with ''0 < u < 2^32''
 * The public keys ''pk<sub>1..u</sub>'': ''u'' 32-byte arrays
 
-The algorithm ''KeySort(pk<sub>1..u</sub>)'' is defined as:
+The algorithm '''''KeySort(pk<sub>1..u</sub>)''''' is defined as:
 * Return ''pk<sub>1..u</sub>'' sorted in lexicographical order.
 
 ==== Key Aggregation ====
@@ -77,11 +77,11 @@ Input:
 * The number ''u'' of public keys with ''0 < u < 2^32''
 * The public keys ''pk<sub>1..u</sub>'': ''u'' 32-byte arrays
 
-The algorithm ''KeyAgg(pk<sub>1..u</sub>)'' is defined as:
+The algorithm '''''KeyAgg(pk<sub>1..u</sub>)''''' is defined as:
 * Let ''Q = KeyAggInternal(pk<sub>1..u</sub>)''; fail if that fails.
 * Return ''bytes(Q)''.
 
-The algorithm ''KeyAggInternal(pk<sub>1..u</sub>)'' is defined as:
+The algorithm '''''KeyAggInternal(pk<sub>1..u</sub>)''''' is defined as:
 * For ''i = 1 .. u'':
 ** Let ''a<sub>i</sub> = KeyAggCoeff(pk<sub>1..u</sub>, pk<sub>i</sub>)''.
 ** Let ''P<sub>i</sub> = point(pk<sub>i</sub>)''; fail if that fails.
@@ -89,16 +89,16 @@ The algorithm ''KeyAggInternal(pk<sub>1..u</sub>)'' is defined as:
 * Fail if ''is_infinite(Q)''.
 * Return ''Q''.
 
-The algorithm ''HashKeys(pk<sub>1..u</sub>)'' is defined as:
+The algorithm '''''HashKeys(pk<sub>1..u</sub>)''''' is defined as:
 * Return ''hash<sub>KeyAgg list</sub>(pk<sub>1</sub> || pk<sub>2</sub> || ... || pk<sub>u</sub>)''
 
-The algorithm ''IsSecond(pk<sub>1..u</sub>, pk')'' is defined as:
+The algorithm '''''IsSecond(pk<sub>1..u</sub>, pk')''''' is defined as:
 * For ''j = 1 .. u'':
 ** If ''pk<sub>j</sub> &ne; pk<sub>1</sub>'':
 *** Return ''true'' if ''pk<sub>j</sub> = pk' '', otherwise return ''false''.
 * Return ''false''
 
-The algorithm ''KeyAggCoeff(pk<sub>1..u</sub>, pk')'' is defined as:
+The algorithm '''''KeyAggCoeff(pk<sub>1..u</sub>, pk')''''' is defined as:
 * Let ''L = HashKeys(pk<sub>1..u</sub>)''.
 * If ''IsSecond(pk<sub>1..u</sub>, pk')'':
 ** Return 1
@@ -106,7 +106,7 @@ The algorithm ''KeyAggCoeff(pk<sub>1..u</sub>, pk')'' is defined as:
 
 ==== Nonce Generation ====
 
-The algorithm ''NonceGen()'' is defined as:
+The algorithm '''''NonceGen()''''' is defined as:
 * Generate two random integers ''k<sub>1</sub>, k<sub>2</sub>'' in the range ''1...n-1''
 * Let ''R<sup>*</sup><sub>1</sub> = k<sub>1</sub>⋅G, R<sup>*</sup><sub>2</sub> = k<sub>2</sub>⋅G''
 * Let ''pubnonce = cbytes(R<sup>*</sup><sub>1</sub>) || cbytes(R<sup>*</sup><sub>2</sub>)''
@@ -118,7 +118,7 @@ The algorithm ''NonceGen()'' is defined as:
 * The number ''u'' of ''pubnonces'' with ''0 < u < 2^32''
 * The public nonces ''pubnonce<sub>1..u</sub>'': ''u'' 66-byte arrays
 
-The algorithm ''NonceAgg(pubnonce<sub>1..u</sub>)'' is defined as:
+The algorithm '''''NonceAgg(pubnonce<sub>1..u</sub>)''''' is defined as:
 * For ''i = 1 .. 2'':
 ** For ''j = 1 .. u'':
 *** Let ''R<sub>i,j</sub> = pointc(pubnonce<sub>j</sub>[(i-1)*33:i*33])''; fail if that fails
@@ -156,7 +156,7 @@ Input:
 * The public keys ''pk<sub>1..u</sub>'': ''u'' 32-byte arrays
 * The message ''m'': a 32-byte array
 
-The algorithm ''Sign(secnonce, sk, aggnonce, pk<sub>1..u</sub>, m)'' is defined as:
+The algorithm '''''Sign(secnonce, sk, aggnonce, pk<sub>1..u</sub>, m)''''' is defined as:
 * Let ''R<sub>1</sub> = pointc(aggnonce[0:33]), R<sub>2</sub> = pointc(aggnonce[33:66])''; fail if that fails
 * Let ''Q = KeyAggInternal(pk<sub>1..u</sub>)''; fail if that fails
 * Let ''b = int(hash<sub>MuSig/noncecoef</sub>(aggnonce || bytes(Q) || m)) mod n''
@@ -187,7 +187,7 @@ Input:
 * The message ''m'': a 32-byte array
 * The index of the signer ''i'' in the public nonces and public keys with ''0 < i &le; u''
 
-The algorithm ''PartialSigVerify(psig, pubnonce<sub>1..u</sub>, pk<sub>1..u</sub>, m, i)'' is defined as:
+The algorithm '''''PartialSigVerify(psig, pubnonce<sub>1..u</sub>, pk<sub>1..u</sub>, m, i)''''' is defined as:
 * Let ''aggnonce = NonceAgg(pubnonce<sub>1..u</sub>)''; fail if that fails
 * Run ''PartialSigVerifyInternal(psig, pubnonce<sub>i</sub>, aggnonce, pk<sub>1..u</sub>, pk<sub>i</sub>, m)''
 * Return success iff no failure occurred before reaching this point.
@@ -203,7 +203,7 @@ Input:
 * The public key of the signer ''pk<sup>*</sup>'' (in ''pk<sub>1..u</sub>''): a 32-byte array
 * The message ''m'': a 32-byte array
 
-The algorithm ''PartialSigVerifyInternal(psig, pubnonce, aggnonce, pk<sub>1..u</sub>, pk<sup>*</sup>, m)'' is defined as:
+The algorithm '''''PartialSigVerifyInternal(psig, pubnonce, aggnonce, pk<sub>1..u</sub>, pk<sup>*</sup>, m)''''' is defined as:
 * Let ''s = int(psig)''; fail if ''s &ge; n''
 * Let ''R<sub>1</sub> = pointc(aggnonce[0:33]), R<sub>2</sub> = pointc(aggnonce[33:66])''; fail if that fails
 * Let ''Q = KeyAggInternal(pk<sub>1..u</sub>)''; fail if that fails
@@ -226,7 +226,7 @@ Input:
 * The number ''u'' of signatures with ''0 < u < 2^32''
 * The partial signatures ''psig<sub>1..u</sub>'': ''u'' 32-byte arrays
 
-The algorithm ''PartialSigAgg(R, psig<sub>1..u</sub>)'' is defined as:
+The algorithm '''''PartialSigAgg(R, psig<sub>1..u</sub>)''''' is defined as:
 * For ''i = 1 .. u'':
 ** Let ''s<sub>i</sub> = int(psig<sub>i</sub>)''; fail if ''s<sub>i</sub> &ge; n''.
 * Let ''s = s<sub>1</sub> + ... + s<sub>u</sub> mod n''

--- a/doc/musig-spec.mediawiki
+++ b/doc/musig-spec.mediawiki
@@ -60,6 +60,8 @@ The following conventions are used, with constants as defined for [https://www.s
 ** The function ''point(x)'', where ''x'' is a 32-byte array ("x-only" serialization), returns ''lift_x(int(x))''. Fail if ''lift_x'' fails.
 ** The function ''pointc(x)'', where ''x'' is a 33-byte array (compressed serialization), sets ''P = lift_x(int(x[1:33]))'' and fails if that fails. If ''x[0] = 2'' it returns ''P'' and if ''x[0] = 3'' it returns ''-P''. Otherwise, it fails.
 ** The function ''hash<sub>tag</sub>(x)'' where ''tag'' is a UTF-8 encoded tag name and ''x'' is a byte array returns the 32-byte hash ''SHA256(SHA256(tag) || SHA256(tag) || x)''.
+* Other:
+** Tuples are written by listing the elements within parentheses and separated by commas. For example, ''(2, 3, 1)'' is a tuple.
 
 
 ==== Key Sorting ====
@@ -126,35 +128,51 @@ The algorithm '''''NonceAgg(pubnonce<sub>1..u</sub>)''''' is defined as:
 ** <div id="NonceAgg infinity"></div>Let ''R<sub>i</sub> = R'<sub>i</sub>'' if not ''is_infinite(R'<sub>i</sub>)'', otherwise let R<sub>i</sub> = G'' (see [[#dealing-with-infinity-in-nonce-aggregation|Dealing with Infinity in Nonce Aggregation]])
 * Return ''aggnonce = cbytes(R<sub>1</sub>) || cbytes(R<sub>2</sub>)''
 
-==== Signing ====
+==== Session Context ====
 
-Input:
-* The secret nonce ''secnonce'' that has never been used as input to ''Sign'' before: a 64-byte array
-* The secret key ''sk'': a 32-byte array
+The Session Context is a data structure consisting of the following elements:
 * The aggregate public nonce ''aggnonce'': a 66-byte array
 * The number ''u'' of public keys with ''0 < u < 2^32''
 * The public keys ''pk<sub>1..u</sub>'': ''u'' 32-byte arrays
 * The message ''m'': a 32-byte array
 
-The algorithm '''''Sign(secnonce, sk, aggnonce, pk<sub>1..u</sub>, m)''''' is defined as:
-* Let ''R<sub>1</sub> = pointc(aggnonce[0:33]), R<sub>2</sub> = pointc(aggnonce[33:66])''; fail if that fails
+We write "Let ''(aggnonce, u, pk<sub>1..u</sub>, m) = session_ctx''" to assign names to the elements of a Session Context.
+
+The algorithm '''''GetSessionValues(session_ctx)''''' is defined as:
+* Let ''(aggnonce, u, pk<sub>1..u</sub>, m) = session_ctx''
 * Let ''Q = KeyAggInternal(pk<sub>1..u</sub>)''; fail if that fails
 * Let ''b = int(hash<sub>MuSig/noncecoef</sub>(aggnonce || bytes(Q) || m)) mod n''
+* Let ''R<sub>1</sub> = pointc(aggnonce[0:33]), R<sub>2</sub> = pointc(aggnonce[33:66])''; fail if that fails
 * Let ''R = R<sub>1</sub> + b⋅R<sub>2</sub>''
 * Fail if ''is_infinite(R)''
+* Let ''e = int(hash<sub>BIP0340/challenge</sub>(bytes(R) || bytes(Q) || m)) mod n''
+* Return ''(Q, b, R, e)''
+
+The algorithm '''''GetSessionKeyAggCoeff(session_ctx, P)''''' is defined as:
+* Let ''(_, u, pk<sub>1..u</sub>, _) = session_ctx''
+* Return ''KeyAggCoeff(pk<sub>1..u</sub>, bytes(P))''
+
+==== Signing ====
+
+Input:
+* The secret nonce ''secnonce'' that has never been used as input to ''Sign'' before: a 64-byte array
+* The secret key ''sk'': a 32-byte array
+* The ''session_ctx'': a [[#session-context|Session Context]] data structure
+
+The algorithm '''''Sign(secnonce, sk, session_ctx)''''' is defined as:
+* Let ''(Q, b, R, e) = GetSessionValues(session_ctx)''; fail if that fails
 * Let ''k'<sub>1</sub> = int(secnonce[0:32]), k'<sub>2</sub> = int(secnonce[32:64])''
 * Fail if ''k'<sub>i</sub> = 0'' or ''k'<sub>i</sub> &ge; n'' for ''i = 1..2''
 * Let ''k<sub>1</sub> = k'<sub>1</sub>, k<sub>2</sub> = k'<sub>2</sub> '' if ''has_even_y(R)'', otherwise let ''k<sub>1</sub> = n - k'<sub>1</sub>, k<sub>2</sub> = n - k<sub>2</sub>''
 * Let ''d' = int(sk)''
 * Fail if ''d' = 0'' or ''d' &ge; n''
 * Let ''P = d'⋅G''
+* Let ''mu = GetSessionKeyAggCoeff(session_ctx, P)''; fail if that fails
 * Let ''d = n - d' '' if ''has_even_y(P) `XOR` has_even_y(Q)'', otherwise let ''d = d' ''
-* Let ''e = int(hash<sub>BIP0340/challenge</sub>(bytes(R) || bytes(Q) || m)) mod n''
-* Let ''mu = KeyAggCoeff(pk<sub>1..u</sub>, bytes(P))''
 * Let ''s = (k<sub>1</sub> + b⋅k<sub>2</sub> + e⋅mu⋅d) mod n''
 * Let ''psig = bytes(s)''
 * Let ''pubnonce = cbytes(k'<sub>1</sub>⋅G) || cbytes(k'<sub>2</sub>⋅G)''
-* If ''PartialSigVerifyInternal(psig, pubnonce, aggnonce, pk<sub>1..u</sub>, bytes(P), m)'' (see below) returns failure, abort<ref>Verifying the signature before leaving the signer prevents random or attacker provoked computation errors. This prevents publishing invalid signatures which may leak information about the secret key. It is recommended, but can be omitted if the computation cost is prohibitive.</ref>.
+* If ''PartialSigVerifyInternal(psig, pubnonce, bytes(P), session_ctx)'' (see below) returns failure, abort<ref>Verifying the signature before leaving the signer prevents random or attacker provoked computation errors. This prevents publishing invalid signatures which may leak information about the secret key. It is recommended, but can be omitted if the computation cost is prohibitive.</ref>.
 * Return partial signature ''psig''
 
 ==== Partial Signature Verification ====
@@ -169,7 +187,8 @@ Input:
 
 The algorithm '''''PartialSigVerify(psig, pubnonce<sub>1..u</sub>, pk<sub>1..u</sub>, m, i)''''' is defined as:
 * Let ''aggnonce = NonceAgg(pubnonce<sub>1..u</sub>)''; fail if that fails
-* Run ''PartialSigVerifyInternal(psig, pubnonce<sub>i</sub>, aggnonce, pk<sub>1..u</sub>, pk<sub>i</sub>, m)''
+* Let ''session_ctx = (aggnonce, u, pk<sub>1..u</sub>, m)''
+* Run ''PartialSigVerifyInternal(psig, pubnonce<sub>i</sub>, pk<sub>i</sub>, session_ctx)''
 * Return success iff no failure occurred before reaching this point.
 
 ===== PartialSigVerifyInternal =====
@@ -177,36 +196,30 @@ The algorithm '''''PartialSigVerify(psig, pubnonce<sub>1..u</sub>, pk<sub>1..u</
 Input:
 * The partial signature ''psig'': a 32-byte array
 * The public nonce of the signer ''pubnonce'': a 66-byte array
-* The aggregate public nonce ''aggnonce'': a 66-byte array
-* The number ''u'' of public keys with ''0 < u < 2^32''
-* The public keys ''pk<sub>1..u</sub>'': ''u'' 32-byte arrays
-* The public key of the signer ''pk<sup>*</sup>'' (in ''pk<sub>1..u</sub>''): a 32-byte array
-* The message ''m'': a 32-byte array
+* The public key of the signer ''pk<sup>*</sup>'' (in ''pk<sub>1..u</sub>'' of the session_ctx''): a 32-byte array
+* The ''session_ctx'': a [[#session-context|Session Context]] data structure
 
-The algorithm '''''PartialSigVerifyInternal(psig, pubnonce, aggnonce, pk<sub>1..u</sub>, pk<sup>*</sup>, m)''''' is defined as:
+The algorithm '''''PartialSigVerifyInternal(psig, pubnonce, pk<sup>*</sup>, session_ctx)''''' is defined as:
+* Let ''(Q, b, R, e) = GetSessionValues(session_ctx)''; fail if that fails
 * Let ''s = int(psig)''; fail if ''s &ge; n''
-* Let ''R<sub>1</sub> = pointc(aggnonce[0:33]), R<sub>2</sub> = pointc(aggnonce[33:66])''; fail if that fails
-* Let ''Q = KeyAggInternal(pk<sub>1..u</sub>)''; fail if that fails
-* Let ''b = int(hash<sub>MuSig/noncecoef</sub>(aggnonce || bytes(Q) || m)) mod n''
-* Let ''R = R<sub>1</sub> + b⋅R<sub>2</sub>''
 * Let ''R<sup>*</sup><sub>1</sub> = pointc(pubnonce[0:33]), R<sup>*</sup><sub>2</sub> = pointc(pubnonce[33:66])''
 * Let ''R<sup>*</sup>' = R<sup>*</sup><sub>1</sub> + b⋅R<sup>*</sup><sub>2</sub>''
 * Let ''R<sup>*</sup> = R<sup>*</sup>' '' if ''has_even_y(R)'', otherwise let ''R<sup>*</sup> = -R<sup>*</sup>' ''
-* Let ''e = int(hash<sub>BIP0340/challenge</sub>(bytes(R) || bytes(Q) || m)) mod n''
-* Let ''mu = KeyAggCoeff(pk<sub>1..u</sub>, pk<sup>*</sup>)''
 * Let ''P' = point(pk<sup>*</sup>)''; fail if that fails
 * Let ''P = P' '' if ''has_even_y(Q)'', otherwise let ''P = -P' ''
+* Let ''mu = GetSessionKeyAggCoeff(session_ctx, P)''; fail if that fails
 * Fail if ''s⋅G &ne; R<sup>*</sup> + e⋅mu⋅P''
 * Return success iff no failure occurred before reaching this point.
 
 ==== Partial Signature Aggregation ====
 
 Input:
-* The final nonce ''R'' as created during  ''Sign'' or ''PartialSigVerify'': a point
 * The number ''u'' of signatures with ''0 < u < 2^32''
 * The partial signatures ''psig<sub>1..u</sub>'': ''u'' 32-byte arrays
+* The ''session_ctx'': a [[#session-context|Session Context]] data structure
 
-The algorithm '''''PartialSigAgg(R, psig<sub>1..u</sub>)''''' is defined as:
+The algorithm '''''PartialSigAgg(psig<sub>1..u</sub>, session_ctx)''''' is defined as:
+* Let ''(_, _, R, _) = GetSessionValues(session_ctx)''; fail if that fails
 * For ''i = 1 .. u'':
 ** Let ''s<sub>i</sub> = int(psig<sub>i</sub>)''; fail if ''s<sub>i</sub> &ge; n''.
 * Let ''s = s<sub>1</sub> + ... + s<sub>u</sub> mod n''

--- a/doc/musig-spec.mediawiki
+++ b/doc/musig-spec.mediawiki
@@ -28,8 +28,9 @@ This document is licensed under the 2-clause BSD license.
 * The second unique key in the pubkey list given to ''KeyAgg'' (as well as any keys identical to this key) gets the constant KeyAgg coefficient 1 which saves an exponentiation (see the MuSig2* appendix in the [https://eprint.iacr.org/2020/1261 MuSig2 paper]).
 * The public key inputs are serialized using x-only (32 byte) instead of compressed (33 byte) serialization. The reason for this is that as x-only keys are becoming more common, the full key may not be available.
 * The public nonces are serialized in compressed format (33 bytes). We accept the small overhead compared to x-only serialization to avoid complicating the specification.
+* This specification supports signing for ''tweaked'' aggregate public keys. There are two modes of tweaking. ''Ordinary'' tweaking allows deriving child aggregate public keys per [https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki BIP32]. ''X-only'' tweaking allows creating a [https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki BIP341] Taproot tweak. See section [[#tweaking|Tweaking]] below for details.
 
-=== Specification ===
+=== Notation ===
 
 The following conventions are used, with constants as defined for [https://www.secg.org/sec2-v2.pdf secp256k1]. We note that adapting this specification to other elliptic curves is not straightforward and can result in an insecure scheme<ref>Among other pitfalls, using the specification with a curve whose order is not close to the size of the range of the nonce derivation function is insecure.</ref>.
 * Lowercase variables represent integers or byte arrays.
@@ -47,6 +48,7 @@ The following conventions are used, with constants as defined for [https://www.s
 ** The function ''bytes(x)'', where ''x'' is an integer, returns the 32-byte encoding of ''x'', most significant byte first.
 ** The function ''bytes(P)'', where ''P'' is a point, returns ''bytes(x(P))''.
 ** The function ''has_even_y(P)'', where ''P'' is a point for which ''not is_infinite(P)'', returns ''y(P) mod 2 = 0''.
+** The function ''with_even_y(P)'', where ''P'' is a point, returns ''P'' if ''is_infinite(P)'' or ''has_even_y(P)''. Otherwise,  ''with_even_y(P)'' returns ''-P''.
 ** The function ''cbytes(P)'', where ''P'' is a point, returns ''a || bytes(P)'' where ''a'' is a byte that is ''2'' if ''has_even_y(P)'' and ''3'' otherwise.
 ** The function ''int(x)'', where ''x'' is a 32-byte array, returns the 256-bit unsigned integer whose most significant byte first encoding is ''x''.
 ** The function ''lift_x(x)'', where ''x'' is an integer in range ''0..2<sup>256</sup>-1'', returns the point ''P'' for which ''x(P) = x''<ref>
@@ -63,6 +65,7 @@ The following conventions are used, with constants as defined for [https://www.s
 * Other:
 ** Tuples are written by listing the elements within parentheses and separated by commas. For example, ''(2, 3, 1)'' is a tuple.
 
+=== Specification ===
 
 ==== Key Sorting ====
 
@@ -242,6 +245,20 @@ An implementation may invalidate the secnonce argument after ''Sign'' to avoid a
 Avoiding reuse also implies that the ''NonceGen'' algorithm must compute unbiased, uniformly random values ''k<sub>1</sub>'' and ''k<sub>2</sub>''.
 
 === Remarks on Security and Correctness ===
+
+==== Tweaking ====
+
+This MuSig specification supports two modes of tweaking that correspond to the following algorithms:
+
+Input:
+* ''P'': a point
+* The tweak ''t'': an integer with ''0 &le; t < n ''
+
+The algorithm '''''OrdinaryTweak(P, t)''''' is defined as:
+* Return ''P + t⋅G''
+
+The algorithm '''''XonlyTweak(P, t)''''' is defined as:
+* Return ''with_even_y(P) + t⋅G''
 
 ==== Dealing with Infinity in Nonce Aggregation ====
 

--- a/doc/musig-spec.mediawiki
+++ b/doc/musig-spec.mediawiki
@@ -123,28 +123,8 @@ The algorithm '''''NonceAgg(pubnonce<sub>1..u</sub>)''''' is defined as:
 ** For ''j = 1 .. u'':
 *** Let ''R<sub>i,j</sub> = pointc(pubnonce<sub>j</sub>[(i-1)*33:i*33])''; fail if that fails
 ** Let ''R'<sub>i</sub> = R<sub>i,1</sub> + R<sub>i,2</sub> + ... + R<sub>i,u</sub>''
-** Let ''R<sub>i</sub> = R'<sub>i</sub>'' if not ''is_infinite(R'<sub>i</sub>)'', otherwise let R<sub>i</sub> = G''
+** <div id="NonceAgg infinity"></div>Let ''R<sub>i</sub> = R'<sub>i</sub>'' if not ''is_infinite(R'<sub>i</sub>)'', otherwise let R<sub>i</sub> = G'' (see [[#dealing-with-infinity-in-nonce-aggregation|Dealing with Infinity in Nonce Aggregation]])
 * Return ''aggnonce = cbytes(R<sub>1</sub>) || cbytes(R<sub>2</sub>)''
-
-===== Note on ''is_infinite(R'<sub>i</sub>)'' =====
-
-If ''is_infinite(R'<sub>i</sub>)'' there is at least one dishonest signer (except with negligible probability).
-If we fail here, we will never be able to determine who it is.
-Therefore, we continue so that the culprit is revealed when collecting and verifying partial signatures.
-
-However, dealing with the point at infinity requires defining a serialization and may require extra code complexity in implementations.
-Instead of incurring this complexity, we make two modifications (compared to the MuSig2* appendix in the [https://eprint.iacr.org/2020/1261 MuSig2 paper]) to avoid infinity while still allowing us to detect the dishonest signer:
-* In ''NonceAgg'', if an output ''R'<sub>i</sub>'' would be infinity, instead output the generator (an arbitrary choice).
-* In ''Sign'', implicitly disallow the input ''aggnonce'' to contain infinity (since the serialization format doesn't support it).
-
-The entire ''NonceAgg'' function (both the original and modified version) only depends on publicly available data (the set of public pre-nonces from every signer).
-In the unforgeability proof, ''NonceAgg'' is considered to be performed by an untrusted party; thus modifications to ''NonceAgg'' do not affect the unforgeability of the scheme.
-
-The (implicit) modification to ''Sign'' is equivalent to adding a clause, "abort if the input ''aggnonce'' contained infinity".
-This modification only depends on the publicly available ''aggnonce''.
-Given a successful adversary against the security game (EUF-CMA) for the modified scheme, a reduction can win the security game for the original scheme by simulating the modification (i.e. checking whether to abort) towards the adversary.
-
-We conclude that these two modifications preserve the security of the MuSig2* scheme.
 
 ==== Signing ====
 
@@ -247,6 +227,28 @@ They send the resulting partial signature to every other signer and combine them
 Otherwise, it is possible to extract the secret signing key from the partial signatures.
 An implementation may invalidate the secnonce argument after ''Sign'' to avoid any reuse.
 Avoiding reuse also implies that the ''NonceGen'' algorithm must compute unbiased, uniformly random values ''k<sub>1</sub>'' and ''k<sub>2</sub>''.
+
+=== Remarks on Security and Correctness ===
+
+==== Dealing with Infinity in Nonce Aggregation ====
+
+If it happens that ''is_infinite(R'<sub>i</sub>)'' inside ''[[#NonceAgg infinity|NonceAgg]]''  there is at least one dishonest signer (except with negligible probability).
+If we fail here, we will never be able to determine who it is.
+Therefore, we continue so that the culprit is revealed when collecting and verifying partial signatures.
+
+However, dealing with the point at infinity requires defining a serialization and may require extra code complexity in implementations.
+Instead of incurring this complexity, we make two modifications (compared to the MuSig2* appendix in the [https://eprint.iacr.org/2020/1261 MuSig2 paper]) to avoid infinity while still allowing us to detect the dishonest signer:
+* In ''NonceAgg'', if an output ''R'<sub>i</sub>'' would be infinity, instead output the generator (an arbitrary choice).
+* In ''Sign'', implicitly disallow the input ''aggnonce'' to contain infinity (since the serialization format doesn't support it).
+
+The entire ''NonceAgg'' function (both the original and modified version) only depends on publicly available data (the set of public pre-nonces from every signer).
+In the unforgeability proof, ''NonceAgg'' is considered to be performed by an untrusted party; thus modifications to ''NonceAgg'' do not affect the unforgeability of the scheme.
+
+The (implicit) modification to ''Sign'' is equivalent to adding a clause, "abort if the input ''aggnonce'' contained infinity".
+This modification only depends on the publicly available ''aggnonce''.
+Given a successful adversary against the security game (EUF-CMA) for the modified scheme, a reduction can win the security game for the original scheme by simulating the modification (i.e. checking whether to abort) towards the adversary.
+
+We conclude that these two modifications preserve the security of the MuSig2* scheme.
 
 == Applications ==
 

--- a/src/modules/musig/keyagg.h
+++ b/src/modules/musig/keyagg.h
@@ -18,8 +18,11 @@ typedef struct {
     secp256k1_ge pk;
     secp256k1_fe second_pk_x;
     unsigned char pk_hash[32];
+    /* tweak is identical to value tacc[v] in the specification. */
     secp256k1_scalar tweak;
-    int internal_key_parity;
+    /* parity_acc corresponds to gacc[v] in the spec. If gacc[v] is -1,
+     * parity_acc is 1. Otherwise, parity_acc is 0. */
+    int parity_acc;
 } secp256k1_keyagg_cache_internal;
 
 /* Requires that the saved point is not infinity */

--- a/src/modules/musig/keyagg_impl.h
+++ b/src/modules/musig/keyagg_impl.h
@@ -69,7 +69,7 @@ static void secp256k1_keyagg_cache_save(secp256k1_musig_keyagg_cache *cache, sec
     ptr += 32;
     memcpy(ptr, cache_i->pk_hash, 32);
     ptr += 32;
-    *ptr = cache_i->internal_key_parity;
+    *ptr = cache_i->parity_acc;
     ptr += 1;
     secp256k1_scalar_get_b32(ptr, &cache_i->tweak);
 }
@@ -84,7 +84,7 @@ static int secp256k1_keyagg_cache_load(const secp256k1_context* ctx, secp256k1_k
     ptr += 32;
     memcpy(cache_i->pk_hash, ptr, 32);
     ptr += 32;
-    cache_i->internal_key_parity = *ptr & 1;
+    cache_i->parity_acc = *ptr & 1;
     ptr += 1;
     secp256k1_scalar_set_b32(&cache_i->tweak, ptr, NULL);
     return 1;
@@ -278,7 +278,7 @@ static int secp256k1_musig_pubkey_tweak_add_internal(const secp256k1_context* ct
         return 0;
     }
     if (xonly && secp256k1_extrakeys_ge_even_y(&cache_i.pk)) {
-        cache_i.internal_key_parity ^= 1;
+        cache_i.parity_acc ^= 1;
         secp256k1_scalar_negate(&cache_i.tweak, &cache_i.tweak);
     }
     secp256k1_scalar_add(&cache_i.tweak, &cache_i.tweak, &tweak);

--- a/src/modules/musig/tests_impl.h
+++ b/src/modules/musig/tests_impl.h
@@ -883,7 +883,7 @@ void musig_tweak_test(secp256k1_scratch_space *scratch) {
      * that key. If xonly is set to true, the function f is normalizes the input
      * point to have an even X-coordinate ("xonly-tweaking").
      * Otherwise, the function f is the identity function. */
-    for (i = 1; i < N_TWEAKS; i++) {
+    for (i = 1; i <= N_TWEAKS; i++) {
         unsigned char tweak[32];
         int P_parity;
         int xonly = secp256k1_testrand_bits(1);


### PR DESCRIPTION
~~This is a draft because I still need to add some comment to the implementation that explains how exactly we make `tweak` identical to `t` in `tweak_add`.~~

Based on #171