### PR TITLE
configure: Check compile+link when checking existence of functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -261,13 +261,13 @@ else
 fi
 
 AC_MSG_CHECKING([for __builtin_popcount])
-AC_COMPILE_IFELSE([AC_LANG_SOURCE([[void myfunc() {__builtin_popcount(0);}]])],
+AC_LINK_IFELSE([AC_LANG_SOURCE([[void myfunc() {__builtin_popcount(0);}]])],
     [ AC_MSG_RESULT([yes]);AC_DEFINE(HAVE_BUILTIN_POPCOUNT,1,[Define this symbol if __builtin_popcount is available]) ],
     [ AC_MSG_RESULT([no])
     ])
 
 AC_MSG_CHECKING([for  __builtin_clzll])
-AC_COMPILE_IFELSE([AC_LANG_SOURCE([[void myfunc() { __builtin_clzll(1);}]])],
+AC_LINK_IFELSE([AC_LANG_SOURCE([[void myfunc() { __builtin_clzll(1);}]])],
     [ AC_MSG_RESULT([yes]);AC_DEFINE(HAVE_BUILTIN_CLZLL,1,[Define this symbol if  __builtin_clzll is available]) ],
     [ AC_MSG_RESULT([no])
     ])


### PR DESCRIPTION
Undeclared functions are fine in C but linking will fail.

This is a quick fix. In the long-term we should probably resort to `#ifdef`s as common in upstream.
