### PR TITLE
surjectionproof: fail to generate proofs when an input equals the output

### DIFF
--- a/src/modules/surjection/main_impl.h
+++ b/src/modules/surjection/main_impl.h
@@ -312,7 +312,7 @@ int secp256k1_surjectionproof_generate(const secp256k1_context* ctx, secp256k1_s
      * it is deployed on Liquid and cannot be fixed without a hardfork. We should review
      * this at the same time that we relax the max-256-inputs rule. */
     for (i = 0; i < n_ephemeral_input_tags; i++) {
-        if (memcmp(ephemeral_input_tags[i].data, ephemeral_output_tag->data, sizeof(ephemeral_output_tag->data)) == 0) {
+        if (secp256k1_memcmp_var(ephemeral_input_tags[i].data, ephemeral_output_tag->data, sizeof(ephemeral_output_tag->data)) == 0) {
             return 0;
         }
     }

--- a/src/modules/surjection/main_impl.h
+++ b/src/modules/surjection/main_impl.h
@@ -307,10 +307,14 @@ int secp256k1_surjectionproof_generate(const secp256k1_context* ctx, secp256k1_s
     if (overflow) {
         return 0;
     }
-    /* The only time the input may equal the output is if neither one was blinded in the first place,
-     * i.e. both blinding keys are zero. Otherwise this is a privacy leak. */
-    if (secp256k1_scalar_eq(&tmps, &blinding_key) && !secp256k1_scalar_is_zero(&blinding_key)) {
-        return 0;
+    /* If any input tag is equal to an output tag, verification will fail, because our ring
+     * signature logic would receive a zero-key, which is illegal. This is unfortunate but
+     * it is deployed on Liquid and cannot be fixed without a hardfork. We should review
+     * this at the same time that we relax the max-256-inputs rule. */
+    for (i = 0; i < n_ephemeral_input_tags; i++) {
+        if (memcmp(ephemeral_input_tags[i].data, ephemeral_output_tag->data, sizeof(ephemeral_output_tag->data)) == 0) {
+            return 0;
+        }
     }
     secp256k1_scalar_negate(&tmps, &tmps);
     secp256k1_scalar_add(&blinding_key, &blinding_key, &tmps);

--- a/src/modules/surjection/tests_impl.h
+++ b/src/modules/surjection/tests_impl.h
@@ -543,12 +543,10 @@ void test_input_eq_output(void) {
     CHECK(secp256k1_generator_generate_blinded(ctx, &ephemeral_tag, fixed_tag.data, blinding_key));
     CHECK(!secp256k1_surjectionproof_generate(ctx, &proof, &ephemeral_tag, 1, &ephemeral_tag, input_index, blinding_key, blinding_key));
 
-    /* It succeeds when the blinding factor is 0... (will fix this in the next commit) */
+    /* ...even when the blinding key is zero */
     memset(blinding_key, 0, 32);
     CHECK(secp256k1_generator_generate_blinded(ctx, &ephemeral_tag, fixed_tag.data, blinding_key));
-    CHECK(secp256k1_surjectionproof_generate(ctx, &proof, &ephemeral_tag, 1, &ephemeral_tag, input_index, blinding_key, blinding_key));
-    /* ...but verification doesn't */
-    CHECK(!secp256k1_surjectionproof_verify(ctx, &proof, &ephemeral_tag, 1, &ephemeral_tag));
+    CHECK(!secp256k1_surjectionproof_generate(ctx, &proof, &ephemeral_tag, 1, &ephemeral_tag, input_index, blinding_key, blinding_key));
 }
 
 void test_fixed_vectors(void) {


### PR DESCRIPTION
If any ephemeral input tag equals the ephemeral output tag (i.e. an input asset is exactly equal to the output asset), verification will fail due to an unexpected interaction between our surjectionproof logic and the underlying borromean ring siganture logic. However, our generation code still allows creating proofs like this, "succeeding" in creating bad proofs.

Since we cannot fix the verification side without hardforking Liquid, fix the generation side to fail in this situation.