### PR TITLE
fix include paths in all the -zkp modules

### DIFF
--- a/src/modules/ecdsa_adaptor/main_impl.h
+++ b/src/modules/ecdsa_adaptor/main_impl.h
@@ -7,8 +7,8 @@
 #ifndef SECP256K1_MODULE_ECDSA_ADAPTOR_MAIN_H
 #define SECP256K1_MODULE_ECDSA_ADAPTOR_MAIN_H
 
-#include "include/secp256k1_ecdsa_adaptor.h"
-#include "modules/ecdsa_adaptor/dleq_impl.h"
+#include "../../../include/secp256k1_ecdsa_adaptor.h"
+#include "dleq_impl.h"
 
 /* (R, R', s', dleq_proof) */
 static int secp256k1_ecdsa_adaptor_sig_serialize(unsigned char *adaptor_sig162, secp256k1_ge *r, secp256k1_ge *rp, const secp256k1_scalar *sp, const secp256k1_scalar *dleq_proof_e, const secp256k1_scalar *dleq_proof_s) {

--- a/src/modules/ecdsa_adaptor/tests_impl.h
+++ b/src/modules/ecdsa_adaptor/tests_impl.h
@@ -1,7 +1,7 @@
 #ifndef SECP256K1_MODULE_ECDSA_ADAPTOR_TESTS_H
 #define SECP256K1_MODULE_ECDSA_ADAPTOR_TESTS_H
 
-#include "include/secp256k1_ecdsa_adaptor.h"
+#include "../../../include/secp256k1_ecdsa_adaptor.h"
 
 void rand_scalar(secp256k1_scalar *scalar) {
     unsigned char buf32[32];

--- a/src/modules/ecdsa_s2c/main_impl.h
+++ b/src/modules/ecdsa_s2c/main_impl.h
@@ -7,8 +7,8 @@
 #ifndef SECP256K1_MODULE_ECDSA_S2C_MAIN_H
 #define SECP256K1_MODULE_ECDSA_S2C_MAIN_H
 
-#include "include/secp256k1.h"
-#include "include/secp256k1_ecdsa_s2c.h"
+#include "../../../include/secp256k1.h"
+#include "../../../include/secp256k1_ecdsa_s2c.h"
 
 static void secp256k1_ecdsa_s2c_opening_save(secp256k1_ecdsa_s2c_opening* opening, secp256k1_ge* ge) {
     secp256k1_pubkey_save((secp256k1_pubkey*) opening, ge);

--- a/src/modules/ecdsa_s2c/tests_impl.h
+++ b/src/modules/ecdsa_s2c/tests_impl.h
@@ -7,7 +7,7 @@
 #ifndef SECP256K1_MODULE_ECDSA_S2C_TESTS_H
 #define SECP256K1_MODULE_ECDSA_S2C_TESTS_H
 
-#include "include/secp256k1_ecdsa_s2c.h"
+#include "../../../include/secp256k1_ecdsa_s2c.h"
 
 static void test_ecdsa_s2c_tagged_hash(void) {
     unsigned char tag_data[14] = "s2c/ecdsa/data";

--- a/src/modules/generator/main_impl.h
+++ b/src/modules/generator/main_impl.h
@@ -9,10 +9,10 @@
 
 #include <stdio.h>
 
-#include "field.h"
-#include "group.h"
-#include "hash.h"
-#include "scalar.h"
+#include "../../field.h"
+#include "../../group.h"
+#include "../../hash.h"
+#include "../../scalar.h"
 
 static void secp256k1_generator_load(secp256k1_ge* ge, const secp256k1_generator* gen) {
     int succeed;

--- a/src/modules/generator/tests_impl.h
+++ b/src/modules/generator/tests_impl.h
@@ -10,12 +10,12 @@
 #include <string.h>
 #include <stdio.h>
 
-#include "group.h"
-#include "scalar.h"
-#include "testrand.h"
-#include "util.h"
+#include "../../group.h"
+#include "../../scalar.h"
+#include "../../testrand.h"
+#include "../../util.h"
 
-#include "include/secp256k1_generator.h"
+#include "../../../include/secp256k1_generator.h"
 
 void test_generator_api(void) {
     unsigned char key[32];

--- a/src/modules/rangeproof/borromean.h
+++ b/src/modules/rangeproof/borromean.h
@@ -8,11 +8,11 @@
 #ifndef _SECP256K1_BORROMEAN_H_
 #define _SECP256K1_BORROMEAN_H_
 
-#include "scalar.h"
-#include "field.h"
-#include "group.h"
-#include "ecmult.h"
-#include "ecmult_gen.h"
+#include "../../scalar.h"
+#include "../../field.h"
+#include "../../group.h"
+#include "../../ecmult.h"
+#include "../../ecmult_gen.h"
 
 int secp256k1_borromean_verify(secp256k1_scalar *evalues, const unsigned char *e0, const secp256k1_scalar *s,
  const secp256k1_gej *pubs, const size_t *rsizes, size_t nrings, const unsigned char *m, size_t mlen);

--- a/src/modules/rangeproof/borromean_impl.h
+++ b/src/modules/rangeproof/borromean_impl.h
@@ -8,13 +8,13 @@
 #ifndef _SECP256K1_BORROMEAN_IMPL_H_
 #define _SECP256K1_BORROMEAN_IMPL_H_
 
-#include "scalar.h"
-#include "field.h"
-#include "group.h"
-#include "hash.h"
-#include "eckey.h"
-#include "ecmult.h"
-#include "ecmult_gen.h"
+#include "../../scalar.h"
+#include "../../field.h"
+#include "../../group.h"
+#include "../../hash.h"
+#include "../../eckey.h"
+#include "../../ecmult.h"
+#include "../../ecmult_gen.h"
 #include "borromean.h"
 
 #include <limits.h>

--- a/src/modules/rangeproof/main_impl.h
+++ b/src/modules/rangeproof/main_impl.h
@@ -7,11 +7,11 @@
 #ifndef SECP256K1_MODULE_RANGEPROOF_MAIN
 #define SECP256K1_MODULE_RANGEPROOF_MAIN
 
-#include "group.h"
+#include "../../group.h"
 
-#include "modules/rangeproof/pedersen_impl.h"
-#include "modules/rangeproof/borromean_impl.h"
-#include "modules/rangeproof/rangeproof_impl.h"
+#include "pedersen_impl.h"
+#include "borromean_impl.h"
+#include "rangeproof_impl.h"
 
 /** Alternative generator for secp256k1.
  *  This is the sha256 of 'g' after standard encoding (without compression),

--- a/src/modules/rangeproof/pedersen.h
+++ b/src/modules/rangeproof/pedersen.h
@@ -7,9 +7,9 @@
 #ifndef _SECP256K1_PEDERSEN_H_
 #define _SECP256K1_PEDERSEN_H_
 
-#include "ecmult_gen.h"
-#include "group.h"
-#include "scalar.h"
+#include "../../ecmult_gen.h"
+#include "../../group.h"
+#include "../../scalar.h"
 
 #include <stdint.h>
 

--- a/src/modules/rangeproof/pedersen_impl.h
+++ b/src/modules/rangeproof/pedersen_impl.h
@@ -9,13 +9,13 @@
 
 #include <string.h>
 
-#include "eckey.h"
-#include "ecmult_const.h"
-#include "ecmult_gen.h"
-#include "group.h"
-#include "field.h"
-#include "scalar.h"
-#include "util.h"
+#include "../../eckey.h"
+#include "../../ecmult_const.h"
+#include "../../ecmult_gen.h"
+#include "../../group.h"
+#include "../../field.h"
+#include "../../scalar.h"
+#include "../../util.h"
 
 static void secp256k1_pedersen_scalar_set_u64(secp256k1_scalar *sec, uint64_t value) {
     unsigned char data[32];

--- a/src/modules/rangeproof/rangeproof.h
+++ b/src/modules/rangeproof/rangeproof.h
@@ -7,10 +7,10 @@
 #ifndef _SECP256K1_RANGEPROOF_H_
 #define _SECP256K1_RANGEPROOF_H_
 
-#include "scalar.h"
-#include "group.h"
-#include "ecmult.h"
-#include "ecmult_gen.h"
+#include "../../scalar.h"
+#include "../../group.h"
+#include "../../ecmult.h"
+#include "../../ecmult_gen.h"
 
 static int secp256k1_rangeproof_verify_impl(const secp256k1_ecmult_gen_context* ecmult_gen_ctx,
  unsigned char *blindout, uint64_t *value_out, unsigned char *message_out, size_t *outlen, const unsigned char *nonce,

--- a/src/modules/rangeproof/rangeproof_impl.h
+++ b/src/modules/rangeproof/rangeproof_impl.h
@@ -7,16 +7,15 @@
 #ifndef _SECP256K1_RANGEPROOF_IMPL_H_
 #define _SECP256K1_RANGEPROOF_IMPL_H_
 
-#include "eckey.h"
-#include "scalar.h"
-#include "group.h"
-#include "rangeproof.h"
-#include "hash_impl.h"
-#include "pedersen_impl.h"
-#include "util.h"
+#include "../../eckey.h"
+#include "../../scalar.h"
+#include "../../group.h"
+#include "../../hash_impl.h"
+#include "../../util.h"
 
-#include "modules/rangeproof/pedersen.h"
-#include "modules/rangeproof/borromean.h"
+#include "pedersen.h"
+#include "rangeproof.h"
+#include "borromean.h"
 
 SECP256K1_INLINE static void secp256k1_rangeproof_pub_expand(secp256k1_gej *pubs,
  int exp, size_t *rsizes, size_t rings, const secp256k1_ge* genp) {

--- a/src/modules/rangeproof/tests_impl.h
+++ b/src/modules/rangeproof/tests_impl.h
@@ -9,12 +9,12 @@
 
 #include <string.h>
 
-#include "group.h"
-#include "scalar.h"
-#include "testrand.h"
-#include "util.h"
+#include "../../group.h"
+#include "../../scalar.h"
+#include "../../testrand.h"
+#include "../../util.h"
 
-#include "include/secp256k1_rangeproof.h"
+#include "../../../include/secp256k1_rangeproof.h"
 
 static void test_pedersen_api(const secp256k1_context *none, const secp256k1_context *sign, const secp256k1_context *vrfy, const secp256k1_context *sttc, const int32_t *ecount) {
     secp256k1_pedersen_commitment commit;

--- a/src/modules/surjection/main_impl.h
+++ b/src/modules/surjection/main_impl.h
@@ -13,11 +13,11 @@
 #include "libsecp256k1-config.h"
 #endif
 
-#include "include/secp256k1_rangeproof.h"
-#include "include/secp256k1_surjectionproof.h"
-#include "modules/rangeproof/borromean.h"
-#include "modules/surjection/surjection_impl.h"
-#include "hash.h"
+#include "../../../include/secp256k1_rangeproof.h"
+#include "../../../include/secp256k1_surjectionproof.h"
+#include "../rangeproof/borromean.h"
+#include "surjection_impl.h"
+#include "../../hash.h"
 
 #ifdef USE_REDUCED_SURJECTION_PROOF_SIZE
 #undef SECP256K1_SURJECTIONPROOF_MAX_USED_INPUTS

--- a/src/modules/surjection/surjection.h
+++ b/src/modules/surjection/surjection.h
@@ -7,8 +7,8 @@
 #ifndef _SECP256K1_SURJECTION_H_
 #define _SECP256K1_SURJECTION_H_
 
-#include "group.h"
-#include "scalar.h"
+#include "../../group.h"
+#include "../../scalar.h"
 
 SECP256K1_INLINE static int secp256k1_surjection_genmessage(unsigned char *msg32, secp256k1_ge *ephemeral_input_tags, size_t n_input_tags, secp256k1_ge *ephemeral_output_tag);
 

--- a/src/modules/surjection/surjection_impl.h
+++ b/src/modules/surjection/surjection_impl.h
@@ -10,10 +10,10 @@
 #include <assert.h>
 #include <string.h>
 
-#include "eckey.h"
-#include "group.h"
-#include "scalar.h"
-#include "hash.h"
+#include "../../eckey.h"
+#include "../../group.h"
+#include "../../scalar.h"
+#include "../../hash.h"
 
 SECP256K1_INLINE static void secp256k1_surjection_genmessage(unsigned char *msg32, const secp256k1_generator *ephemeral_input_tags, size_t n_input_tags, const secp256k1_generator *ephemeral_output_tag) {
     /* compute message */

--- a/src/modules/surjection/tests_impl.h
+++ b/src/modules/surjection/tests_impl.h
@@ -7,11 +7,11 @@
 #ifndef SECP256K1_MODULE_SURJECTIONPROOF_TESTS
 #define SECP256K1_MODULE_SURJECTIONPROOF_TESTS
 
-#include "testrand.h"
-#include "group.h"
-#include "include/secp256k1_generator.h"
-#include "include/secp256k1_rangeproof.h"
-#include "include/secp256k1_surjectionproof.h"
+#include "../../testrand.h"
+#include "../../group.h"
+#include "../../../include/secp256k1_generator.h"
+#include "../../../include/secp256k1_rangeproof.h"
+#include "../../../include/secp256k1_surjectionproof.h"
 
 static void test_surjectionproof_api(void) {
     unsigned char seed[32];

--- a/src/modules/whitelist/main_impl.h
+++ b/src/modules/whitelist/main_impl.h
@@ -7,8 +7,8 @@
 #ifndef SECP256K1_MODULE_WHITELIST_MAIN
 #define SECP256K1_MODULE_WHITELIST_MAIN
 
-#include "include/secp256k1_whitelist.h"
-#include "modules/whitelist/whitelist_impl.h"
+#include "../../../include/secp256k1_whitelist.h"
+#include "whitelist_impl.h"
 
 #define MAX_KEYS SECP256K1_WHITELIST_MAX_N_KEYS  /* shorter alias */
 

--- a/src/modules/whitelist/tests_impl.h
+++ b/src/modules/whitelist/tests_impl.h
@@ -7,7 +7,7 @@
 #ifndef SECP256K1_MODULE_WHITELIST_TESTS
 #define SECP256K1_MODULE_WHITELIST_TESTS
 
-#include "include/secp256k1_whitelist.h"
+#include "../../../include/secp256k1_whitelist.h"
 
 void test_whitelist_end_to_end_internal(const unsigned char *summed_seckey, const unsigned char *online_seckey, const secp256k1_pubkey *online_pubkeys, const secp256k1_pubkey *offline_pubkeys, const secp256k1_pubkey *sub_pubkey, const size_t signer_i, const size_t n_keys) {
         unsigned char serialized[32 + 4 + 32 * SECP256K1_WHITELIST_MAX_N_KEYS] = {0};


### PR DESCRIPTION
This is causing out-of-tree build failures in Elements.