### PR TITLE
rangeproof: add a test for all-zero blinding factors

### DIFF
--- a/include/secp256k1_rangeproof.h
+++ b/include/secp256k1_rangeproof.h
@@ -227,7 +227,8 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_rangeproof_rewind(
  *          proof:  pointer to array to receive the proof, can be up to 5134 bytes. (cannot be NULL)
  *          min_value: constructs a proof where the verifer can tell the minimum value is at least the specified amount.
  *          commit: the commitment being proved.
- *          blind:  32-byte blinding factor used by commit.
+ *          blind:  32-byte blinding factor used by commit. The blinding factor may be all-zeros as long as min_bits is set to 3 or greater.
+ *                  This is a side-effect of the underlying crypto, not a deliberate API choice, but it may be useful when balancing CT transactions.
  *          nonce:  32-byte secret nonce used to initialize the proof (value can be reverse-engineered out of the proof if this secret is known.)
  *          exp:    Base-10 exponent. Digits below above will be made public, but the proof will be made smaller. Allowed range is -1 to 18.
  *                  (-1 is a special case that makes the value public. 0 is the most private.)

--- a/src/modules/ecdsa_s2c/tests_impl.h
+++ b/src/modules/ecdsa_s2c/tests_impl.h
@@ -78,7 +78,7 @@ void run_s2c_opening_test(void) {
          * points' x-coordinates are uniformly random */
         if (secp256k1_ecdsa_s2c_opening_parse(none, &opening, input) == 1) {
             CHECK(secp256k1_ecdsa_s2c_opening_serialize(none, output, &opening) == 1);
-            CHECK(memcmp(output, input, sizeof(output)) == 0);
+            CHECK(secp256k1_memcmp_var(output, input, sizeof(output)) == 0);
         }
         secp256k1_testrand256(&input[1]);
         /* Set pubkey oddness tag to first bit of input[1] */
@@ -255,7 +255,7 @@ static void test_ecdsa_s2c_fixed_vectors(void) {
         secp256k1_ecdsa_signature signature;
         CHECK(secp256k1_ecdsa_s2c_sign(ctx, &signature, &s2c_opening, message, privkey, test->s2c_data) == 1);
         CHECK(secp256k1_ecdsa_s2c_opening_serialize(ctx, opening_ser, &s2c_opening) == 1);
-        CHECK(memcmp(test->expected_s2c_opening, opening_ser, sizeof(opening_ser)) == 0);
+        CHECK(secp256k1_memcmp_var(test->expected_s2c_opening, opening_ser, sizeof(opening_ser)) == 0);
         CHECK(secp256k1_ecdsa_s2c_verify_commit(ctx, &signature, test->s2c_data, &s2c_opening) == 1);
     }
 }
@@ -331,7 +331,7 @@ static void test_ecdsa_anti_exfil_signer_commit(void) {
         const ecdsa_s2c_test *test = &ecdsa_s2c_tests[i];
         CHECK(secp256k1_ecdsa_anti_exfil_signer_commit(ctx, &s2c_opening, message, privkey, test->s2c_data) == 1);
         CHECK(secp256k1_ecdsa_s2c_opening_serialize(ctx, buf, &s2c_opening) == 1);
-        CHECK(memcmp(test->expected_s2c_exfil_opening, buf, sizeof(buf)) == 0);
+        CHECK(secp256k1_memcmp_var(test->expected_s2c_exfil_opening, buf, sizeof(buf)) == 0);
     }
 }
 
@@ -397,7 +397,7 @@ static void test_ecdsa_anti_exfil(void) {
         CHECK(secp256k1_ecdsa_verify(ctx, &signature, host_msg, &signer_pubkey) == 1);
         CHECK(secp256k1_anti_exfil_host_verify(ctx, &signature, host_msg, &signer_pubkey, host_nonce_contribution, &s2c_opening) == 0);
         CHECK(secp256k1_anti_exfil_host_verify(ctx, &signature, host_msg, &signer_pubkey, bad_nonce_contribution, &s2c_opening) == 1);
-        CHECK(memcmp(&s2c_opening, &orig_opening, sizeof(s2c_opening)) != 0);
+        CHECK(secp256k1_memcmp_var(&s2c_opening, &orig_opening, sizeof(s2c_opening)) != 0);
     }
 }
 

--- a/src/modules/generator/tests_impl.h
+++ b/src/modules/generator/tests_impl.h
@@ -134,7 +134,7 @@ void test_shallue_van_de_woestijne(void) {
             shallue_van_de_woestijne(&ge, &fe);
             secp256k1_ge_to_storage(&ges, &ge);
 
-            CHECK(memcmp(&ges, &results[i * 2 + s - 2], sizeof(secp256k1_ge_storage)) == 0);
+            CHECK(secp256k1_memcmp_var(&ges, &results[i * 2 + s - 2], sizeof(secp256k1_ge_storage)) == 0);
         }
     }
 }
@@ -188,11 +188,11 @@ void test_generator_generate(void) {
         CHECK(secp256k1_generator_generate_blinded(ctx, &gen, v, s));
         secp256k1_generator_load(&ge, &gen);
         secp256k1_ge_to_storage(&ges, &ge);
-        CHECK(memcmp(&ges, &results[i - 1], sizeof(secp256k1_ge_storage)) == 0);
+        CHECK(secp256k1_memcmp_var(&ges, &results[i - 1], sizeof(secp256k1_ge_storage)) == 0);
         CHECK(secp256k1_generator_generate(ctx, &gen, v));
         secp256k1_generator_load(&ge, &gen);
         secp256k1_ge_to_storage(&ges, &ge);
-        CHECK(memcmp(&ges, &results[i - 1], sizeof(secp256k1_ge_storage)) == 0);
+        CHECK(secp256k1_memcmp_var(&ges, &results[i - 1], sizeof(secp256k1_ge_storage)) == 0);
     }
 
     /* There is no range restriction on the value, but the blinder must be a
@@ -215,7 +215,7 @@ void test_generator_fixed_vector(void) {
 
     CHECK(secp256k1_generator_parse(ctx, &parse, two_g));
     CHECK(secp256k1_generator_serialize(ctx, result, &parse));
-    CHECK(memcmp(two_g, result, 33) == 0);
+    CHECK(secp256k1_memcmp_var(two_g, result, 33) == 0);
 
     result[0] = 0x0a;
     CHECK(secp256k1_generator_parse(ctx, &parse, result));

--- a/src/modules/musig/tests_impl.h
+++ b/src/modules/musig/tests_impl.h
@@ -360,7 +360,7 @@ void musig_api_tests(secp256k1_scratch_space *scratch) {
         secp256k1_musig_pubnonce tmp;
         CHECK(secp256k1_musig_pubnonce_serialize(none, pubnonce_ser, &pubnonce[0]) == 1);
         CHECK(secp256k1_musig_pubnonce_parse(none, &tmp, pubnonce_ser) == 1);
-        CHECK(memcmp(&tmp, &pubnonce[0], sizeof(tmp)) == 0);
+        CHECK(secp256k1_memcmp_var(&tmp, &pubnonce[0], sizeof(tmp)) == 0);
     }
 
     /** Receive nonces and aggregate **/
@@ -414,7 +414,7 @@ void musig_api_tests(secp256k1_scratch_space *scratch) {
         secp256k1_musig_aggnonce tmp;
         CHECK(secp256k1_musig_aggnonce_serialize(none, aggnonce_ser, &aggnonce) == 1);
         CHECK(secp256k1_musig_aggnonce_parse(none, &tmp, aggnonce_ser) == 1);
-        CHECK(memcmp(&tmp, &aggnonce, sizeof(tmp)) == 0);
+        CHECK(secp256k1_memcmp_var(&tmp, &aggnonce, sizeof(tmp)) == 0);
     }
 
     /** Process nonces **/
@@ -444,7 +444,7 @@ void musig_api_tests(secp256k1_scratch_space *scratch) {
     memcpy(&secnonce_tmp, &secnonce[0], sizeof(secnonce_tmp));
     CHECK(secp256k1_musig_partial_sign(none, &partial_sig[0], &secnonce_tmp, &keypair[0], &keyagg_cache, &session) == 1);
     /* The secnonce is set to 0 and subsequent signing attempts fail */
-    CHECK(memcmp(&secnonce_tmp, zeros68, sizeof(secnonce_tmp)) == 0);
+    CHECK(secp256k1_memcmp_var(&secnonce_tmp, zeros68, sizeof(secnonce_tmp)) == 0);
     CHECK(secp256k1_musig_partial_sign(none, &partial_sig[0], &secnonce_tmp, &keypair[0], &keyagg_cache, &session) == 0);
     CHECK(ecount == 1);
     memcpy(&secnonce_tmp, &secnonce[0], sizeof(secnonce_tmp));
@@ -496,7 +496,7 @@ void musig_api_tests(secp256k1_scratch_space *scratch) {
         secp256k1_musig_partial_sig tmp;
         CHECK(secp256k1_musig_partial_sig_serialize(none, buf, &partial_sig[0]) == 1);
         CHECK(secp256k1_musig_partial_sig_parse(none, &tmp, buf) == 1);
-        CHECK(memcmp(&tmp, &partial_sig[0], sizeof(tmp)) == 0);
+        CHECK(secp256k1_memcmp_var(&tmp, &partial_sig[0], sizeof(tmp)) == 0);
     }
 
     /** Partial signature verification */
@@ -582,10 +582,10 @@ void musig_api_tests(secp256k1_scratch_space *scratch) {
     /** Secret adaptor can be extracted from signature */
     ecount = 0;
     CHECK(secp256k1_musig_extract_adaptor(none, sec_adaptor1, final_sig, pre_sig, nonce_parity) == 1);
-    CHECK(memcmp(sec_adaptor, sec_adaptor1, 32) == 0);
+    CHECK(secp256k1_memcmp_var(sec_adaptor, sec_adaptor1, 32) == 0);
     /* wrong nonce parity */
     CHECK(secp256k1_musig_extract_adaptor(none, sec_adaptor1, final_sig, pre_sig, !nonce_parity) == 1);
-    CHECK(memcmp(sec_adaptor, sec_adaptor1, 32) != 0);
+    CHECK(secp256k1_memcmp_var(sec_adaptor, sec_adaptor1, 32) != 0);
     CHECK(secp256k1_musig_extract_adaptor(none, NULL, final_sig, pre_sig, 0) == 0);
     CHECK(ecount == 1);
     CHECK(secp256k1_musig_extract_adaptor(none, sec_adaptor1, NULL, pre_sig, 0) == 0);
@@ -764,7 +764,7 @@ void scriptless_atomic_swap(secp256k1_scratch_space *scratch) {
     CHECK(secp256k1_musig_partial_sign(ctx, &partial_sig_a[1], &secnonce_a[1], &keypair_a[1], &keyagg_cache_a, &session_a) == 1);
     CHECK(secp256k1_musig_partial_sig_agg(ctx, pre_sig_a, &session_a, partial_sig_a_ptr, 2) == 1);
     CHECK(secp256k1_musig_extract_adaptor(ctx, sec_adaptor_extracted, final_sig_b, pre_sig_b, nonce_parity_b) == 1);
-    CHECK(memcmp(sec_adaptor_extracted, sec_adaptor, sizeof(sec_adaptor)) == 0); /* in real life we couldn't check this, of course */
+    CHECK(secp256k1_memcmp_var(sec_adaptor_extracted, sec_adaptor, sizeof(sec_adaptor)) == 0); /* in real life we couldn't check this, of course */
     CHECK(secp256k1_musig_adapt(ctx, final_sig_a, pre_sig_a, sec_adaptor_extracted, nonce_parity_a) == 1);
     CHECK(secp256k1_schnorrsig_verify(ctx, final_sig_a, msg32_a, sizeof(msg32_a), &agg_pk_a) == 1);
 }
@@ -794,7 +794,7 @@ void sha256_tag_test_internal(secp256k1_sha256 *sha_tagged, unsigned char *tag, 
     secp256k1_sha256_write(sha_tagged, buf, 32);
     secp256k1_sha256_finalize(&sha, buf);
     secp256k1_sha256_finalize(sha_tagged, buf2);
-    CHECK(memcmp(buf, buf2, 32) == 0);
+    CHECK(secp256k1_memcmp_var(buf, buf2, 32) == 0);
 }
 
 /* Checks that the initialized tagged hashes initialized have the expected
@@ -904,7 +904,7 @@ void musig_tweak_test(secp256k1_scratch_space *scratch) {
         } else {
             secp256k1_pubkey tmp_key = P[i-1];
             CHECK(secp256k1_ec_pubkey_tweak_add(ctx, &tmp_key, tweak));
-            CHECK(memcmp(&tmp_key, &P[i], sizeof(tmp_key)) == 0);
+            CHECK(secp256k1_memcmp_var(&tmp_key, &P[i], sizeof(tmp_key)) == 0);
         }
         /* Test signing for P[i] */
         musig_tweak_test_helper(&P_xonly[i], sk[0], sk[1], &keyagg_cache);
@@ -1138,7 +1138,7 @@ void musig_test_vectors_noncegen(void) {
         for (j = 0; j < 2; j++) {
             unsigned char k32[32];
             secp256k1_scalar_get_b32(k32, &k[i][j]);
-            CHECK(memcmp(k32, k32_expected[i][j], 32) == 0);
+            CHECK(secp256k1_memcmp_var(k32, k32_expected[i][j], 32) == 0);
         }
     }
 }
@@ -1264,7 +1264,7 @@ void musig_test_vectors_sign(void) {
         CHECK(musig_test_pk_parity(&keyagg_cache) == 1);
         CHECK(!musig_test_is_second_pk(&keyagg_cache, sk));
         CHECK(fin_nonce_parity == 1);
-        CHECK(memcmp(sig, sig_expected, 32) == 0);
+        CHECK(secp256k1_memcmp_var(sig, sig_expected, 32) == 0);
     }
     {
        /* This is a test where the aggregate public key point has an _even_ y
@@ -1281,7 +1281,7 @@ void musig_test_vectors_sign(void) {
         CHECK(musig_test_pk_parity(&keyagg_cache) == 0);
         CHECK(musig_test_is_second_pk(&keyagg_cache, sk));
         CHECK(fin_nonce_parity == 0);
-        CHECK(memcmp(sig, sig_expected, 32) == 0);
+        CHECK(secp256k1_memcmp_var(sig, sig_expected, 32) == 0);
     }
     {
        /* This is a test where the parity of aggregate public key point (1) is unequal to the
@@ -1297,7 +1297,7 @@ void musig_test_vectors_sign(void) {
         CHECK(musig_test_pk_parity(&keyagg_cache) == 1);
         CHECK(fin_nonce_parity == 0);
         CHECK(!musig_test_is_second_pk(&keyagg_cache, sk));
-        CHECK(memcmp(sig, sig_expected, 32) == 0);
+        CHECK(secp256k1_memcmp_var(sig, sig_expected, 32) == 0);
     }
     {
        /* This is a test that includes an xonly public key tweak. */
@@ -1319,7 +1319,7 @@ void musig_test_vectors_sign(void) {
         CHECK(musig_test_pk_parity(&keyagg_cache) == 1);
         CHECK(!musig_test_is_second_pk(&keyagg_cache, sk));
         CHECK(fin_nonce_parity == 1);
-        CHECK(memcmp(sig, sig_expected, 32) == 0);
+        CHECK(secp256k1_memcmp_var(sig, sig_expected, 32) == 0);
     }
     {
        /* This is a test that includes an ordinary public key tweak. */
@@ -1341,7 +1341,7 @@ void musig_test_vectors_sign(void) {
         CHECK(musig_test_pk_parity(&keyagg_cache) == 1);
         CHECK(!musig_test_is_second_pk(&keyagg_cache, sk));
         CHECK(fin_nonce_parity == 0);
-        CHECK(memcmp(sig, sig_expected, 32) == 0);
+        CHECK(secp256k1_memcmp_var(sig, sig_expected, 32) == 0);
     }
     {
        /* This is a test that includes an ordinary and an x-only public key tweak. */
@@ -1371,7 +1371,7 @@ void musig_test_vectors_sign(void) {
         CHECK(musig_test_pk_parity(&keyagg_cache) == 0);
         CHECK(!musig_test_is_second_pk(&keyagg_cache, sk));
         CHECK(fin_nonce_parity == 0);
-        CHECK(memcmp(sig, sig_expected, 32) == 0);
+        CHECK(secp256k1_memcmp_var(sig, sig_expected, 32) == 0);
     }
     {
        /* This is a test with four tweaks: x-only, ordinary, x-only, ordinary. */
@@ -1412,7 +1412,7 @@ void musig_test_vectors_sign(void) {
         CHECK(musig_test_pk_parity(&keyagg_cache) == 0);
         CHECK(!musig_test_is_second_pk(&keyagg_cache, sk));
         CHECK(fin_nonce_parity == 1);
-        CHECK(memcmp(sig, sig_expected, 32) == 0);
+        CHECK(secp256k1_memcmp_var(sig, sig_expected, 32) == 0);
     }
     {
        /* This is a test that includes an adaptor. */
@@ -1435,7 +1435,7 @@ void musig_test_vectors_sign(void) {
         CHECK(musig_test_pk_parity(&keyagg_cache) == 1);
         CHECK(!musig_test_is_second_pk(&keyagg_cache, sk));
         CHECK(fin_nonce_parity == 1);
-        CHECK(memcmp(sig, sig_expected, 32) == 0);
+        CHECK(secp256k1_memcmp_var(sig, sig_expected, 32) == 0);
     }
 }
 

--- a/src/modules/rangeproof/borromean_impl.h
+++ b/src/modules/rangeproof/borromean_impl.h
@@ -105,7 +105,7 @@ int secp256k1_borromean_verify(secp256k1_scalar *evalues, const unsigned char *e
     }
     secp256k1_sha256_write(&sha256_e0, m, mlen);
     secp256k1_sha256_finalize(&sha256_e0, tmp);
-    return memcmp(e0, tmp, 32) == 0;
+    return secp256k1_memcmp_var(e0, tmp, 32) == 0;
 }
 
 int secp256k1_borromean_sign(const secp256k1_ecmult_gen_context *ecmult_gen_ctx,

--- a/src/modules/rangeproof/rangeproof_impl.h
+++ b/src/modules/rangeproof/rangeproof_impl.h
@@ -401,7 +401,7 @@ SECP256K1_INLINE static int secp256k1_rangeproof_rewind_inner(secp256k1_scalar *
         idx = npub + rsizes[rings - 1] - 1 - j;
         secp256k1_scalar_get_b32(tmp, &s[idx]);
         secp256k1_rangeproof_ch32xor(tmp, &prep[idx * 32]);
-        if ((tmp[0] & 128) && (memcmp(&tmp[16], &tmp[24], 8) == 0) && (memcmp(&tmp[8], &tmp[16], 8) == 0)) {
+        if ((tmp[0] & 128) && (secp256k1_memcmp_var(&tmp[16], &tmp[24], 8) == 0) && (secp256k1_memcmp_var(&tmp[8], &tmp[16], 8) == 0)) {
             value = 0;
             for (i = 0; i < 8; i++) {
                 value = (value << 8) + tmp[24 + i];

--- a/src/modules/rangeproof/tests_impl.h
+++ b/src/modules/rangeproof/tests_impl.h
@@ -196,7 +196,7 @@ static void test_rangeproof_api(const secp256k1_context *none, const secp256k1_c
         CHECK(max_value >= val);
         CHECK(value_out == val);
         CHECK(message_len == sizeof(message_out));
-        CHECK(memcmp(message, message_out, sizeof(message_out)) == 0);
+        CHECK(secp256k1_memcmp_var(message, message_out, sizeof(message_out)) == 0);
 
         CHECK(secp256k1_rangeproof_rewind(both, NULL, &value_out, message_out, &message_len, commit.data, &min_value, &max_value, &commit, proof, len, ext_commit, ext_commit_len, secp256k1_generator_h) != 0);
         CHECK(*ecount == 21);  /* blindout may be NULL */
@@ -434,13 +434,13 @@ static void test_rangeproof(void) {
             mlen = 4096;
             CHECK(secp256k1_rangeproof_rewind(ctx, blindout, &vout, message, &mlen, commit.data, &minv, &maxv, &commit, proof, len, NULL, 0, secp256k1_generator_h));
             if (input_message != NULL) {
-                CHECK(memcmp(message, input_message, input_message_len) == 0);
+                CHECK(secp256k1_memcmp_var(message, input_message, input_message_len) == 0);
             }
             for (j = input_message_len; j < mlen; j++) {
                 CHECK(message[j] == 0);
             }
             CHECK(mlen <= 4096);
-            CHECK(memcmp(blindout, blind, 32) == 0);
+            CHECK(secp256k1_memcmp_var(blindout, blind, 32) == 0);
             CHECK(vout == v);
             CHECK(minv <= v);
             CHECK(maxv >= v);
@@ -448,7 +448,7 @@ static void test_rangeproof(void) {
             CHECK(secp256k1_rangeproof_sign(ctx, proof, &len, v, &commit, blind, commit.data, -1, 64, v, NULL, 0, NULL, 0, secp256k1_generator_h));
             CHECK(len <= 73);
             CHECK(secp256k1_rangeproof_rewind(ctx, blindout, &vout, NULL, NULL, commit.data, &minv, &maxv, &commit, proof, len, NULL, 0, secp256k1_generator_h));
-            CHECK(memcmp(blindout, blind, 32) == 0);
+            CHECK(secp256k1_memcmp_var(blindout, blind, 32) == 0);
             CHECK(vout == v);
             CHECK(minv == v);
             CHECK(maxv == v);
@@ -460,7 +460,7 @@ static void test_rangeproof(void) {
             CHECK(!secp256k1_rangeproof_rewind(ctx, blindout, &vout, NULL, NULL, commit.data, &minv, &maxv, &commit, proof, len, NULL, 0, secp256k1_generator_h));
             CHECK(!secp256k1_rangeproof_rewind(ctx, blindout, &vout, NULL, NULL, commit.data, &minv, &maxv, &commit, proof, len, message_long, sizeof(message_long), secp256k1_generator_h));
             CHECK(secp256k1_rangeproof_rewind(ctx, blindout, &vout, NULL, NULL, commit.data, &minv, &maxv, &commit, proof, len, message_short, sizeof(message_short), secp256k1_generator_h));
-            CHECK(memcmp(blindout, blind, 32) == 0);
+            CHECK(secp256k1_memcmp_var(blindout, blind, 32) == 0);
             CHECK(vout == v);
             CHECK(minv == v);
             CHECK(maxv == v);
@@ -527,7 +527,7 @@ static void test_rangeproof(void) {
             CHECK(message[j] == 0);
         }
         CHECK(mlen <= 4096);
-        CHECK(memcmp(blindout, blind, 32) == 0);
+        CHECK(secp256k1_memcmp_var(blindout, blind, 32) == 0);
 
         CHECK(minv <= v);
         CHECK(maxv >= v);
@@ -591,8 +591,8 @@ static void test_rangeproof_null_blinder(void) {
         secp256k1_testrand256(&msg[96]);
         CHECK(secp256k1_rangeproof_sign(ctx, proof, &len, v, &commit, blind, commit.data, 0, 3, v, msg, sizeof(msg), NULL, 0, secp256k1_generator_h));
         CHECK(secp256k1_rangeproof_rewind(ctx, blind_out, &value_out, msg_out, &msg_len, commit.data, &minv, &maxv, &commit, proof, len, NULL, 0, secp256k1_generator_h) != 0);
-        CHECK(memcmp(blind, blind_out, sizeof(blind)) == 0);
-        CHECK(memcmp(msg, msg_out, sizeof(msg)) == 0);
+        CHECK(secp256k1_memcmp_var(blind, blind_out, sizeof(blind)) == 0);
+        CHECK(secp256k1_memcmp_var(msg, msg_out, sizeof(msg)) == 0);
         CHECK(value_out == v);
         CHECK(minv == v);
         CHECK(maxv == v + 7);
@@ -737,7 +737,7 @@ void test_pedersen_commitment_fixed_vector(void) {
 
     CHECK(secp256k1_pedersen_commitment_parse(ctx, &parse, two_g));
     CHECK(secp256k1_pedersen_commitment_serialize(ctx, result, &parse));
-    CHECK(memcmp(two_g, result, 33) == 0);
+    CHECK(secp256k1_memcmp_var(two_g, result, 33) == 0);
 
     result[0] = 0x08;
     CHECK(secp256k1_pedersen_commitment_parse(ctx, &parse, result));

--- a/src/modules/surjection/main_impl.h
+++ b/src/modules/surjection/main_impl.h
@@ -243,7 +243,7 @@ int secp256k1_surjectionproof_initialize(const secp256k1_context* ctx, secp256k1
             while (1) {
                 size_t next_input_index;
                 next_input_index = secp256k1_surjectionproof_csprng_next(&csprng, n_input_tags);
-                if (memcmp(&fixed_input_tags[next_input_index], fixed_output_tag, sizeof(*fixed_output_tag)) == 0) {
+                if (secp256k1_memcmp_var(&fixed_input_tags[next_input_index], fixed_output_tag, sizeof(*fixed_output_tag)) == 0) {
                     *input_index = next_input_index;
                     has_output_tag = 1;
                 }


### PR DESCRIPTION
I was curious about under what conditions you can create a rangeproof on an "unblinded" commitment which has a zero blinding factor. Apparently the answer is "when you are proving at least 3-bits". In this case rewinding words and you can encode 32 bytes of data. (In fact I believe you can encode up to 128 but I haven't tested that.)

