### PR TITLE
shut up spurious gcc warning

### DIFF
--- a/src/modules/surjection/main_impl.h
+++ b/src/modules/surjection/main_impl.h
@@ -284,7 +284,7 @@ int secp256k1_surjectionproof_generate(const secp256k1_context* ctx, secp256k1_s
     size_t n_used_pubkeys;
     size_t ring_input_index = 0;
     secp256k1_gej ring_pubkeys[SECP256K1_SURJECTIONPROOF_MAX_USED_INPUTS];
-    secp256k1_scalar borromean_s[SECP256K1_SURJECTIONPROOF_MAX_USED_INPUTS];
+    secp256k1_scalar borromean_s[SECP256K1_SURJECTIONPROOF_MAX_USED_INPUTS] = { 0 };
     unsigned char msg32[32];
 
     VERIFY_CHECK(ctx != NULL);


### PR DESCRIPTION
gcc 12.1.1 has a new warning:
```
In file included from src/secp256k1.c:846,
                 from src/tests_exhaustive.c:20:
src/modules/surjection/main_impl.h: In function ‘secp256k1_surjectionproof_generate’:
src/modules/surjection/main_impl.h:343:24: warning: ‘borromean_s’ may be used uninitialized [-Wmaybe-uninitialized]
  343 |     nonce = borromean_s[ring_input_index];
      |             ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
```

The warning is spurious but add some code to shut it up anyway.