### PR TITLE
sync-upstream: Restore SYNC_PAT

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -5,9 +5,6 @@ on:
     - cron: '0 0 1 * *'
   workflow_dispatch:
 
-permissions:
-  pull-requests: write
-
 jobs:
   sync-upstream:
     runs-on: ubuntu-latest
@@ -32,7 +29,7 @@ jobs:
       - name: Fetch upstream & generate branch name & check for new commits
         id: check_commits
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SYNC_PAT }}
         run: |
           gh repo set-default ${{ github.repository }}  # Set the default repo to the origin repository
           git remote add upstream ${{ env.UPSTREAM }}
@@ -82,7 +79,7 @@ jobs:
         id: create_pr
         if: steps.check_commits.outputs.skip == 'false'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SYNC_PAT }}
         run: |
           # Execute the generated PR creation script
           ./contrib/gh-pr-create.sh 

--- a/contrib/sync-upstream.sh
+++ b/contrib/sync-upstream.sh
@@ -69,7 +69,7 @@ PR_BRANCH=$1
 range
 
 TITLE="Upstream PRs"
-BODY=""
+BODY="${GITHUB_ACTIONS+This PR has been created by a GitHub Actions workflow without human involvement.}"$'\n'
 for COMMIT in $COMMITS
 do
     PRNUM=$(git log -1 "$COMMIT" --pretty=format:%s | sed s/'Merge \(bitcoin-core\/secp256k1\)\?#\([0-9]*\).*'/'\2'/)


### PR DESCRIPTION
This PR restores the `SYNC_PAT` requirement due to restrictions on opening PRs with the default 'GITHUB_TOKEN'. 

Since the authorship of the PR is now linked to the user who created the PAT, a note was added to the PR body to clarify that it was created by a GitHub Actions workflow and not by a human being. 

Additionally, the `permissions:` section has been removed, as `GITHUB_TOKEN` is no longer in use.
