### PR TITLE
Upstream PRs 1846, 1848, 1849

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -604,11 +604,10 @@ jobs:
     steps:
       - *CHECKOUT
 
-      - name: Add cl.exe to PATH
-        uses: ilammy/msvc-dev-cmd@v1
-
       - name: C++ (public headers)
+        shell: cmd
         run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cl.exe -c -WX -TP include/*.h
 
   cxx_fpermissive_debian:

--- a/ci/linux-debian.Dockerfile
+++ b/ci/linux-debian.Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
         apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Build and install gcc snapshot
-ARG GCC_SNAPSHOT_MAJOR=16
+ARG GCC_SNAPSHOT_MAJOR=17
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     wget libgmp-dev libmpfr-dev libmpc-dev flex && \
     mkdir gcc && cd gcc && \

--- a/src/modules/musig/session_impl.h
+++ b/src/modules/musig/session_impl.h
@@ -483,11 +483,9 @@ int secp256k1_musig_nonce_gen_counter(const secp256k1_context* ctx, secp256k1_mu
     (void) ret;
 #endif
 
-    if (!secp256k1_musig_nonce_gen_internal(ctx, secnonce, pubnonce, buf, seckey, &pubkey, msg32, keyagg_cache, extra_input32)) {
-        return 0;
-    }
+    ret = secp256k1_musig_nonce_gen_internal(ctx, secnonce, pubnonce, buf, seckey, &pubkey, msg32, keyagg_cache, extra_input32);
     secp256k1_memclear_explicit(seckey, sizeof(seckey));
-    return 1;
+    return ret;
 }
 
 static int secp256k1_musig_sum_pubnonces(const secp256k1_context* ctx, secp256k1_gej *summed_pubnonces, const secp256k1_musig_pubnonce * const* pubnonces, size_t n_pubnonces) {


### PR DESCRIPTION
This PR has been created by a GitHub Actions workflow without human involvement.

[bitcoin-core/secp256k1#1846]: ci: Replace `ilammy/msvc-dev-cmd` with manual MSVC setup
[bitcoin-core/secp256k1#1848]: ci: Bump GCC snapshot major version to 17
[bitcoin-core/secp256k1#1849]: musig: always clear out secret key in `secp256k1_musig_nonce_gen_counter`

Tips:
 * Use `git show --remerge-diff <pr-branch>` to show the conflict resolution in the merge commit.
 * Use `git read-tree --reset -u <pr-branch>` to replay these resolutions during the conflict resolution stage when recreating the PR branch locally.
   Be aware that this may discard your index as well as the uncommitted changes and untracked files in your worktree.